### PR TITLE
Ci/#5 Vercel 배포 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['develop']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: JANGSEYEONG
+          destination-repository-name: PRism-FE
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: develop
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./PRism-FE/* ./output
+cp -R ./output ./PRism-FE/


### PR DESCRIPTION
## 💡 ISSUE 번호

#5 

<br/>

## 🔎 작업 내용

- Organization Secret key 생성
- `build.sh` 생성 : action flow 시 실행할 명령어
- `.github/workflows/deploy.yml` 생성 : develop branch에 push 시 개인 계정 repo로 자동 push

<br/>

## 📢 주의 및 리뷰 요청

- Vercel의 Organization Repository 연동은 체험 기간 이후 유료 결제를 해야하는 문제가 있습니다.
- 개인 플랜은 무료기에, Organization Repository의 develop branch에 push 이벤트가 발생할 경우 개인 Repository의 develop branch에도 자동 push가 되게 연동하여 Vercel에 자동 배포가 되도록 했습니다.
- 잘 세팅되었는지 확인이 필요해 이 코드 merge 후에 pr 테스트가 필요합니다!


_*Vercel 연동 된 개인 Repository : https://github.com/JANGSEYEONG/PRism-FE_

<br/>

## 🔗 Reference

-  https://velog.io/@rmaomina/organization-vercel-hobby-deploy
