### PR TITLE
Feat/#31 공통 메시지박스,모달 닫기 옵션 추가

### DIFF
--- a/src/components/common/information/MessageBox.tsx
+++ b/src/components/common/information/MessageBox.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import ModalLayout from '@/components/modal/ModalLayout';
+import { Button } from '@/components/ui/button';
+import { useModalStore } from '@/stores/modalStore';
+
+import { cn } from '@/lib/utils';
+
+// 제목, 버튼 필수
+interface MessageBoxProps {
+  title: React.ReactNode;
+  titleIcon?: JSX.Element;
+  subTitle?: string; // with Color
+  description?: string;
+  footer: React.ReactNode;
+}
+
+export default function MessageBox({
+  title,
+  titleIcon,
+  subTitle,
+  description = '',
+  footer,
+}: MessageBoxProps) {
+  return (
+    <div className="shadow-custom-6px">
+      <ModalLayout
+        title={
+          <div className="flex-col-center">
+            {titleIcon && <div className="mb-3 flex justify-center">{titleIcon}</div>}
+            <div className="body2">{title}</div>
+            {subTitle && <div className="mt-1 text-purple-800 display4">{subTitle}</div>}
+          </div>
+        }
+        description={description}
+        contentClassName="w-fit px-[100px]"
+        transparentOverlay={true}
+        footer={<div className="mt-5 w-full gap-1 flex-center">{footer}</div>}
+      />
+    </div>
+  );
+}
+
+interface MessageBoxButtonProps {
+  text: string;
+  onClick: () => void;
+  isPrimary?: boolean; // 보라색 강조 버튼 여부
+}
+
+const MessageConfirmButton = ({ text, onClick, isPrimary = true }: MessageBoxButtonProps) => {
+  const { closeModal } = useModalStore();
+  const handleClick = () => {
+    closeModal();
+    onClick();
+  };
+  return (
+    <Button
+      className={cn(
+        isPrimary
+          ? 'bg-purple-500 text-white mobile2 hover:bg-purple-600'
+          : 'border border-gray-700 bg-white text-gray-700 hover:bg-gray-50',
+      )}
+      onClick={handleClick}>
+      {text}
+    </Button>
+  );
+};
+
+MessageBox.MessageConfirmButton = MessageConfirmButton;

--- a/src/components/modal/ModalLayout.tsx
+++ b/src/components/modal/ModalLayout.tsx
@@ -10,13 +10,17 @@ import {
 import { useModalStore } from '@/stores/modalStore';
 import { Button } from '@/components/ui/button';
 
+import { cn } from '@/lib/utils';
+
 interface ModalLayoutProps {
   title?: React.ReactNode;
   description?: string;
   children?: React.ReactNode;
   footer?: React.ReactNode;
+  contentClassName?: string;
   showCloseButton?: boolean;
   preventOutsideClose?: boolean;
+  transparentOverlay?: boolean;
 }
 
 export default function ModalLayout({
@@ -24,24 +28,27 @@ export default function ModalLayout({
   description,
   children,
   footer,
+  contentClassName = '',
   showCloseButton = true,
   preventOutsideClose = true,
+  transparentOverlay = false,
 }: ModalLayoutProps) {
   const closeModal = useModalStore((state) => state.closeModal);
   const hasDescription = !!description;
   return (
     <Dialog open onOpenChange={closeModal}>
       <DialogContent
-        className="max-h-[90vh] overflow-y-auto p-11"
+        className={cn(`max-h-[90vh] overflow-y-auto p-11`, contentClassName)}
         showCloseButton={showCloseButton}
+        transparentOverlay={transparentOverlay}
         onInteractOutside={(event) => {
           if (preventOutsideClose) {
             event.preventDefault();
           }
         }}>
-        <DialogHeader className="flex flex-col items-center text-center">
+        <DialogHeader className="flex-col-center">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription className={`${hasDescription ? '' : 'hidden'}`}>
+          <DialogDescription className={cn('mobile1', hasDescription ? '' : 'hidden')}>
             {hasDescription ? description : ''}
           </DialogDescription>
         </DialogHeader>
@@ -59,6 +66,7 @@ interface ConfirmButtonProps {
   disabled?: boolean;
 }
 
+// 전체 너비의 확인 버튼
 const ConfirmButton = ({ title, isSmallScreen, onClick, disabled }: ConfirmButtonProps) => {
   return (
     <Button

--- a/src/components/modal/ModalLayout.tsx
+++ b/src/components/modal/ModalLayout.tsx
@@ -16,6 +16,7 @@ interface ModalLayoutProps {
   children?: React.ReactNode;
   footer?: React.ReactNode;
   showCloseButton?: boolean;
+  preventOutsideClose?: boolean;
 }
 
 export default function ModalLayout({
@@ -24,6 +25,7 @@ export default function ModalLayout({
   children,
   footer,
   showCloseButton = true,
+  preventOutsideClose = true,
 }: ModalLayoutProps) {
   const closeModal = useModalStore((state) => state.closeModal);
   const hasDescription = !!description;
@@ -31,7 +33,12 @@ export default function ModalLayout({
     <Dialog open onOpenChange={closeModal}>
       <DialogContent
         className="max-h-[90vh] overflow-y-auto p-11"
-        showCloseButton={showCloseButton}>
+        showCloseButton={showCloseButton}
+        onInteractOutside={(event) => {
+          if (preventOutsideClose) {
+            event.preventDefault();
+          }
+        }}>
         <DialogHeader className="flex flex-col items-center text-center">
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription className={`${hasDescription ? '' : 'hidden'}`}>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,15 +31,18 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }
->(({ className, children, showCloseButton = true, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+    transparentOverlay?: boolean;
+  }
+>(({ className, children, showCloseButton = true, transparentOverlay = false, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={transparentOverlay ? 'bg-black/0' : ''} />
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'relative mx-4 w-full max-w-lg rounded-[30px] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:mx-0',
+          'relative mx-4 w-full max-w-2xl rounded-[30px] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:mx-0',
           className,
         )}
         {...props}>


### PR DESCRIPTION
## 💡 ISSUE 번호

#31 

<br/>

## 🔎 작업 내용

### ModalLayout 외부 영역 클릭 옵션 추가
- ModalLayout에 preventOutsideClose Prop을 추가하여 외부 영역 클릭 시 모달 창 닫음 여부를 옵션처리 (default: 외부영역 클릭 시 안닫힘)

### MessageBox 추가

- ui/dialog 아토믹 컴포넌트 수정
  - 타이틀의 길이가 긴 경우로 인해 max-width 수정
  - transparentOverlay 넘겨받아 배경을 투명하게 바꾸는 조건 추가 (메시지박스는 배경이 어두워지지 않아야해서 ModalLayout에서 부터 transparentOverlay prop 추가)

- ModalLayout 수정
  - DialogContent의 기본 패딩값, 너비 설정으로 인해 메시지박스가 어색하게 표시되는 경우가 있어, contentClassName prop을 추가해 너비와 패딩을 커스텀할 수 있도록 함

- MessageBox 추가
  - 메시지박스의 버튼들은 Component Composition으로 선언 (가져다 쓸 때 MessageBox.MessageConfirmButton 형태로 쓰면 됩니다.)
  - 버튼은 isPrimary 를 통해 강조되는 버튼과 강조되지 않는 버튼을 구분

**<props 설명>**
title과 버튼인 footer는 필수입니다.
<img width="399" alt="image" src="https://github.com/user-attachments/assets/8c59b5d8-5529-44b2-8c5e-19f999732fc9">

**<각 메시지 종류 별 로컬 메시지박스 활용한 화면 캡처본>**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/46e25750-d6cf-4957-81b8-3bb752e7df50">

**사용 예시**
```jsx
    <MessageBox
        title={
          <div className="flex-col-center">
            <div>이제 팀원들이 평가한 내 협업 능력을 분석한</div>
            <div className="flex items-center">
              나의{'\u00A0'}
              <span className="text-purple-500">PRism</span> 을 볼 수 있어요!
            </div>
          </div>
        }
        description="팀원들의 평가 참여도가 높을수록 분석 결과가 정확해요."
        titleIcon={<Mail className="h-6 w-6 stroke-purple-600" />}
        footer={
          <MessageBox.MessageConfirmButton
            text="내 평가 결과 보러가기"
            isPrimary={false}
            onClick={() => {
              alert('평가보내기');
            }}
          />
        }
      />
```

<br/>

## 📢 주의 및 리뷰 요청

- 모달의 기본값을 외부 영역 클릭 시 닫히지 않도록 설정한 이유는 지금까지 추가된 모든 모달은 외부 영역으로 닫히지 않는 모달이기 때문입니다. 추후 모달 추가 시, 외부 영역으로 닫혀도 된다면 true로 설정해야 합니다.

- ModalLayout에 header와 footer를 적당히 넘겨 메시지박스처럼 이용해도 될텐데, 굳이 공통 컴포넌트를 만들어야할까? 라는 의문이 있었습니다. 의문점에서 시작하여 고민을 해본 결과 다음과 같은 이유로 추가하는 것이 좋을 것이라 생각했습니다.
  1. `메시지 박스 용도임을 명시` : 사용하는 곳에서 메시지박스임을 명시하고, content에 다른 요소들을 넣지 않고 헤더, 설명, 푸터만 제공
  2. `일관성 있는 메시지 박스 ui 표시` : 메시지박스의 정형화된 틀에 맞춰지도록  기준 제공
  3. `중복 코드 방지` : ModalLayout에 커스텀 해야 하는 부분이 많은데, 메시지박스 사용 컴포넌트마다 중복 코드가 작성될 것을 방지

- shadcn의 Alert Dialog를 활용하여 바깥 영역을 눌러도 꺼지지 않는 모달창을 만들 순 있었으나, 또 저희 프로젝트에 맞게 커스텀 해야해서 Dialog를 재사용하는 것이 맞다고 생각했습니다. 

<br/>

## 🔗 Reference

- Dialog 컴포넌트 외부 클릭 제어: https://github.com/shadcn-ui/ui/issues/1712