### PR TITLE
Feat/#29 로그인 api 연동

### DIFF
--- a/src/components/domain/auth/login/LoginModal.tsx
+++ b/src/components/domain/auth/login/LoginModal.tsx
@@ -7,6 +7,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { LoginSchema, LoginForm } from '@/models/auth/authModels';
+import { login } from '@/services/api/authApi';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PasswordInput } from '@/components/common/input/PasswordInput';
@@ -20,6 +21,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import axios from 'axios';
 
 export default function LoginModal() {
   const id = useId();
@@ -40,9 +42,25 @@ export default function LoginModal() {
     formState: { errors, isValid },
   } = formMethods;
 
-  // NOTE: alert는 api 연동하면서 수정할 예정입니다. 현재는 data를 담고 있습니다.
-  const onSubmit = (data: LoginForm) => {
-    alert(JSON.stringify(data));
+  const onSubmit = async (data: LoginForm) => {
+    try {
+      const response = await login(data);
+      const { accessToken, refreshToken } = response.data;
+
+      // 토큰을 로컬 스토리지에 저장
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+
+      closeModal();
+      alert('로그인에 성공했습니다.');
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const errorMessage = error.response?.data?.message || '로그인 중 오류가 발생했습니다.';
+        alert(errorMessage);
+      } else {
+        alert('로그인 중 오류가 발생했습니다.');
+      }
+    }
   };
 
   const handleOpenSignupModal = () => {

--- a/src/models/auth/authApiModels.ts
+++ b/src/models/auth/authApiModels.ts
@@ -42,3 +42,17 @@ export interface SignupResponse {
     email: string;
   };
 }
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  success: boolean;
+  status: number;
+  data: {
+    accessToken: string;
+    refreshToken: string;
+  };
+}

--- a/src/services/api/authApi.ts
+++ b/src/services/api/authApi.ts
@@ -8,6 +8,8 @@ import {
   SignupResponse,
   VerifyAuthCodeRequest,
   VerifyAuthCodeResponse,
+  LoginRequest,
+  LoginResponse,
 } from '@/models/auth/authApiModels';
 
 // NOTE: 개발을 위해 임시로 로그를 많이 추가해두었습니다. 배포 전 삭제할 예정입니다.
@@ -79,6 +81,23 @@ export const signup = async (data: SignupRequest): Promise<SignupResponse> => {
     } else {
       console.error(`회원가입 실패: ${error}`);
       throw new Error(`회원가입 실패: ${error}`);
+    }
+  }
+};
+
+export const login = async (data: LoginRequest): Promise<LoginResponse> => {
+  try {
+    const response = await ax.post<LoginResponse>('/api/v1/auth/login', data);
+    console.log('Login Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`로그인 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`로그인 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`로그인 실패: ${error}`);
+      throw new Error(`로그인 실패: ${error}`);
     }
   }
 };


### PR DESCRIPTION
## 💡 ISSUE 번호

#29 

<br/>

## 🔎 작업 내용

- 로그인 api 연동

<br/>

## 📢 주의 및 리뷰 요청

- 로그인 API의 응답을 `response`에 담았고, 로컬 스토리지에 액세스 토큰과 리프레시 토큰을 저장하는 부분은 `response` 객체에서 값을 추출하여 저장한 상태입니다. (임시)
- 로그인 기능 정상동작 확인했고, 여기까지 말씀하신게 맞는지 잘 모르겠는데, 혹시 제가 추가로 작업해야 될 부분이 있다면 알려주세요. 퇴근 후 수정하겠습니다.

<br/>
