### PR TITLE
Feat/#18 프로젝트 등록 api 연동

### DIFF
--- a/src/components/common/messgeBox/MessageBox.tsx
+++ b/src/components/common/messgeBox/MessageBox.tsx
@@ -33,7 +33,7 @@ export default function MessageBox({
           </div>
         }
         description={description}
-        contentClassName="w-fit px-[100px]"
+        contentClassName="max-w-[500px] px-[50px]"
         transparentOverlay={true}
         footer={<div className="mt-5 w-full gap-1 flex-center">{footer}</div>}
       />

--- a/src/components/common/tooltip/InformationTooltip.tsx
+++ b/src/components/common/tooltip/InformationTooltip.tsx
@@ -7,10 +7,16 @@ interface InformationTooltipProps {
 }
 
 export default function InformationTooltip({ message, side = 'bottom' }: InformationTooltipProps) {
+  // TooltipTrigger 컴포넌트의 기본 동작 막기
+  // (TooltipTrigger는 button 태그라, form 내부에 있을 때 클릭 시 submit 되어버려서 문제가 생김)
+  const handleTooltipTriggerClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.preventDefault();
+  };
+
   return (
     <TooltipProvider delayDuration={150}>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger onClick={handleTooltipTriggerClick}>
           <AlertCircle className="h-4 w-4 stroke-gray-400 hover:fill-gray-200" />
         </TooltipTrigger>
         <TooltipContent side={side}>

--- a/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
@@ -1,10 +1,15 @@
 'use client';
 
+import { cn } from '@/lib/utils';
+
 import { Button } from '@/components/ui/button';
 import { ClipboardEdit } from 'lucide-react';
-import { useModalStore } from '@/stores/modalStore';
+
+import LoginModal from '../../auth/login/LoginModal';
 import ProjectRegisterModal from '@/components/domain/project/projectRegisterModal/ProjectRegisterModal';
-import { cn } from '@/lib/utils';
+
+import { useAuthStore } from '@/stores/authStore';
+import { useModalStore } from '@/stores/modalStore';
 
 interface ProjectRegisterButtonProps {
   className?: string;
@@ -12,8 +17,14 @@ interface ProjectRegisterButtonProps {
 
 export default function ProjectRegisterButton({ className }: ProjectRegisterButtonProps) {
   const openModal = useModalStore((state) => state.openModal);
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   const handleOpenProject = () => {
+    if (!isLoggedIn) {
+      alert('로그인하고 프로젝트를 시작해보세요!'); // 임시 alert
+      openModal(<LoginModal />);
+      return;
+    }
     openModal(<ProjectRegisterModal />);
   };
 

--- a/src/components/domain/project/projectRegisterModal/step/Step2.tsx
+++ b/src/components/domain/project/projectRegisterModal/step/Step2.tsx
@@ -17,6 +17,7 @@ import type { ProjectForm, ProjectMember } from '@/models/project/projectModels'
 import { useModalStore } from '@/stores/modalStore';
 import SelectTagModalLayout from '@/components/common/modal/SelectTagModalLayout';
 import { UserRoles } from '@/lib/tagList';
+import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 
 const DEFAULT_MEMBER: ProjectMember = { name: '', email: '', roles: [] };
 const PRIORITY_ERROR_FIELDS: (keyof FieldErrors<ProjectMember>)[] = ['name', 'email', 'roles']; // error 우선순위대로 선언
@@ -72,7 +73,13 @@ export default function Step2() {
   return (
     <section className="flex flex-col">
       <FormItem>
-        <FormLabel className="text-purple-500 mobile1">팀원정보*</FormLabel>
+        <div className="item-center flex gap-1">
+          <FormLabel className="text-purple-500 mobile1">팀원정보*</FormLabel>
+          <InformationTooltip
+            side="right"
+            message="익명으로 원할 경우, 해당 팀원이 직접 ‘MY PAGE’ 에서 설정가능해요!"
+          />
+        </div>
         <FormDescription className="text-gray-500 caption">
           프로젝트에 참여한 팀원의 정보를 알려주세요
         </FormDescription>

--- a/src/components/domain/project/projectRegisterModal/step/Step3.tsx
+++ b/src/components/domain/project/projectRegisterModal/step/Step3.tsx
@@ -25,8 +25,8 @@ import { useModalStore } from '@/stores/modalStore';
 import SelectTagModalLayout from '@/components/common/modal/SelectTagModalLayout';
 
 export default function Step3() {
-  const { control, setValue, watch } = useFormContext<ProjectForm>();
   const openModal = useModalStore((state) => state.openModal);
+  const { control, setValue, watch } = useFormContext<ProjectForm>();
 
   // 프로젝트 스킬
   const currentSkills = watch('skills');

--- a/src/components/domain/project/projectRegisterModal/step/Step3.tsx
+++ b/src/components/domain/project/projectRegisterModal/step/Step3.tsx
@@ -5,7 +5,7 @@ import { useTagListState } from '@/hooks/useTagListState';
 import TagInput from '@/components/common/input/TagInput';
 import IconInput from '@/components/common/input/IconInput';
 import CheckTagInput from '@/components/common/input/CheckTagInput';
-import InformationTooltip from '@/components/common/tooltip/InfoTooltip';
+import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 import MaxLengthMultiTextArea from '@/components/common/input/MaxLengthMultiTextInput';
 
 import {
@@ -113,7 +113,7 @@ export default function Step3() {
                   </li>
                 ))}
                 <TagInput
-                  value="역할"
+                  value="JavaScript"
                   onClick={handleOpenSkillsModal}
                   colorTheme="gray"
                   buttonType="add"

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -1,0 +1,18 @@
+import { ProjectCreateRequest, ProjectCreateResponse } from '@/models/project/projectApiModels';
+import { createProject } from '@/services/api/projectApi';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const useCreateProject = (successCallback: () => void) => {
+  return useMutation<ProjectCreateResponse, AxiosError, ProjectCreateRequest>({
+    mutationFn: createProject,
+    onSuccess: (response) => {
+      console.log(response);
+      if (successCallback) successCallback();
+    },
+    onError: (error) => {
+      alert('프로젝트 등록에 실패했습니다.');
+      console.log(error);
+    },
+  });
+};

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -5,7 +5,7 @@ import { ko } from 'date-fns/locale/ko';
  * @param seconds mm:ss 형태로 변환될 초
  * @returns mm:ss
  */
-export const formatTime = (seconds: number) => {
+export const formatTime = (seconds: number): string => {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
   return `${minutes}:${remainingSeconds < 10 ? '0' : ''}${remainingSeconds}`;
@@ -15,5 +15,13 @@ export const formatTime = (seconds: number) => {
  * @param date yyyy년 MM월 dd일로 변환될 Date 객체
  * @returns yyyy년 MM월 dd일
  */
-export const formatDateToKoreanStyle = (date: Date) =>
+export const formatDateToKoreanStyle = (date: Date): string =>
   format(date, 'yyyy년 MM월 dd일', { locale: ko });
+
+/**
+ * @param date yyyyMMddHHmmss로 변환될 Date 객체
+ * @returns yyyyMMddHHmmss
+ */
+export const formatDateToYYYYMMDDHHmmss = (date: Date): string => {
+  return format(date, 'yyyyMMddHHmmss');
+};

--- a/src/models/project/projectApiModels.ts
+++ b/src/models/project/projectApiModels.ts
@@ -1,0 +1,60 @@
+interface CategoryResponse {
+  id: number;
+  category: {
+    categoryId: number;
+    name: string;
+  };
+}
+
+interface CommonProjectFields {
+  projectName: string;
+  organizationName: string;
+  startDate: string;
+  endDate: string;
+  memberCount: number;
+  projectUrlLink: string;
+  projectDescription: string;
+  skills: string[];
+}
+
+export interface ProjectCreateRequest extends CommonProjectFields {
+  members: {
+    name: string;
+    email: string;
+    roles: string[];
+  }[];
+  categories: string[];
+}
+
+export interface ProjectCreateResponse {
+  success: boolean;
+  status: number;
+  data: CommonProjectFields & {
+    projectId: number;
+    categories: CategoryResponse[];
+  };
+}
+
+// 프로젝트 산출물의 공개, 비공개 여부 추가 필요
+export interface ProjectUpdateRequest extends CommonProjectFields {
+  members: {
+    name: string;
+    email: string;
+    roles: string[];
+  }[];
+  categories: string[]; // id 배열로 바뀔 예정
+}
+export interface ProjectUpdateResponse {
+  success: boolean;
+  status: number;
+  data: CommonProjectFields & {
+    projectId: number;
+    categories: CategoryResponse[];
+  };
+}
+
+export interface ProjectDeleteResponse {
+  success: boolean;
+  status: number;
+  data: null;
+}

--- a/src/services/api/projectApi.ts
+++ b/src/services/api/projectApi.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import { ax } from '../axios';
+import {
+  ProjectCreateRequest,
+  ProjectCreateResponse,
+  ProjectUpdateRequest,
+  ProjectUpdateResponse,
+  ProjectDeleteResponse,
+} from '@/models/project/projectApiModels';
+
+// 프로젝트 등록
+export const createProject = async (data: ProjectCreateRequest): Promise<ProjectCreateResponse> => {
+  try {
+    const response = await ax.post<ProjectCreateResponse>('/api/v1/projects', data);
+    console.log('Create Project Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프로젝트 등록 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프로젝트 등록 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프로젝트 등록 실패: ${error}`);
+      throw new Error(`프로젝트 등록 실패: ${error}`);
+    }
+  }
+};
+
+// 프로젝트 수정
+export const updateProject = async (
+  projectId: number,
+  data: ProjectUpdateRequest,
+): Promise<ProjectUpdateResponse> => {
+  try {
+    const response = await ax.put<ProjectUpdateResponse>(`/api/v1/projects/${projectId}`, data);
+    console.log('Update Project Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프로젝트 수정 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프로젝트 수정 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프로젝트 수정 실패: ${error}`);
+      throw new Error(`프로젝트 수정 실패: ${error}`);
+    }
+  }
+};
+
+// 프로젝트 삭제
+export const deleteProject = async (projectId: number): Promise<ProjectDeleteResponse> => {
+  try {
+    const response = await ax.delete<ProjectDeleteResponse>(`/api/v1/projects/${projectId}`);
+    console.log('Delete Project Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프로젝트 삭제 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프로젝트 삭제 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프로젝트 삭제 실패: ${error}`);
+      throw new Error(`프로젝트 삭제 실패: ${error}`);
+    }
+  }
+};


### PR DESCRIPTION
## 💡 ISSUE 번호

#18 

<br/>

## 🔎 작업 내용

### 공통
- 메시지박스에 최대 기준 없이 `w-fit` + `px-[100px]`를 적용하니, 모달의 x 버튼 위치가 애매한 것 같아 `max-w-[500px]` 속성을 추가하고 패딩값을 조절했습니다. (현재 피그마에 정의된 메시지박스들을 문제없이 나타낼 수 있는 너비가 500px)
- 서버에 보내야하는 date 형식 포맷 함수 추가

### 프로젝트 등록
- 프로젝트 등록 버튼 클릭 이동 처리
  - 비로그인 시 : alert + 로그인 모달창 띄우기
  (이부분은 그냥 임시로 alert를 보여줬습니다. 흐름에 대해서는 나중에 QA하며 기획자분 의견에 따라 진행하는게 좋을 것 같습니다. 또는 좋은 의견 있으시면 전달주세요!! )
  - 로그인 시 : 프로젝트 등록 모달 띄우기
- 프로젝트 등록 api 연동, 성공 시 콜백으로 메세지 박스 띄우는 함수 연결, 메시지박스 버튼 클릭 이벤트 연결
- 프로젝트 등록 api 호출되는 동안 PageSpinner 뜨게 처리 (버튼이 작아 component spinner는 좀 어색했습니다)

<br/>

## 📢 주의 및 리뷰 요청

- 프로젝트 등록 post api를 제외하고는 아직 호출 테스트 안했습니다! 이후 작업하면서 진행하려고합니다.
- 프로젝트 api interface들이 조금 겹치는게 있는데, 구분되는게 좋을 것 같아서 네이밍은 따로 지었습니다. 이건 좀 더 고민해볼게요
- 프로젝트 api interface는 수정, 삭제 작업할 때 최신 api와 다른 부분들과 주석들 수정할 예정입니다 !! (프로젝트 산출물 공개값 같은거 추가 필요)
- api error의 자세한 로그는 우선 axios 호출 부분에만 남겼습니다! useMutation 훅에서는 alert로 하나의 메세지로 처리했습니다

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
