### PR TITLE
Feat/#62 user 요약 카드 컴포넌트 생성 및 마이페이지 상단 user profile 스크린 작업

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import GlobalFooter from './layout/footer/GlobalFooter';
 import GlobalHeader from './layout/header/GlobalHeader';
 import ModalPortal from './layout/modal/ModalPotal';
 import ReactQueryProviders from '@/hooks/useReactQuery';
+import { cn } from '@/lib/utils';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -25,7 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={pretendard.variable}>
-      <body className={pretendard.variable}>
+      <body className={cn(pretendard.variable, 'bg-gray-50')}>
         <ReactQueryProviders>
           <GlobalHeader />
           {children}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,22 @@
+import BorderCard from '@/components/common/card/BorderCard';
+import UserProfile from '@/components/domain/user/userProfile/UserProfile';
+
+export default function MyPage() {
+  return (
+    <>
+      <main className="container mx-auto flex min-h-screen flex-col items-center p-12">
+        <div className="flex w-full justify-end" style={{ width: '90%' }}></div>
+        <div className="flex w-full max-w-[1040px] flex-col">
+          <span className="mb-4 text-gray-900 body6">사용자 프로필</span>
+          <UserProfile />
+        </div>
+        <div className="mt-8 flex w-full max-w-[1040px] flex-col">
+          <span className="mb-4 text-gray-900 body6">프로젝트 목록 </span>
+          <BorderCard className="h-[165px] w-full flex-center">
+            <span className="text-gray-600 display6">등록된 프로젝트가 없습니다.</span>
+          </BorderCard>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -6,12 +6,12 @@ export default function MyPage() {
     <>
       <main className="container mx-auto flex min-h-screen flex-col items-center p-12">
         <div className="flex w-full justify-end" style={{ width: '90%' }}></div>
-        <div className="flex w-full max-w-[1040px] flex-col">
-          <span className="mb-4 text-gray-900 body6">사용자 프로필</span>
+        <div className="flex w-full max-w-[1040px] flex-col gap-4">
+          <span className="text-gray-900 body6">사용자 프로필</span>
           <UserProfile />
         </div>
-        <div className="mt-8 flex w-full max-w-[1040px] flex-col">
-          <span className="mb-4 text-gray-900 body6">프로젝트 목록 </span>
+        <div className="mt-8 flex w-full max-w-[1040px] flex-col gap-4">
+          <span className="text-gray-900 body6">프로젝트 목록 </span>
           <BorderCard className="h-[165px] w-full flex-center">
             <span className="text-gray-600 display6">등록된 프로젝트가 없습니다.</span>
           </BorderCard>

--- a/src/components/common/card/BorderCard.tsx
+++ b/src/components/common/card/BorderCard.tsx
@@ -8,6 +8,8 @@ interface BorderCardProps {
 
 export default function BorderCard({ children, className }: BorderCardProps) {
   return (
-    <div className={cn('rounded-[20px] border border-gray-200 p-4', className)}>{children}</div>
+    <div className={cn('rounded-[20px] border border-gray-300 bg-white p-4', className)}>
+      {children}
+    </div>
   );
 }

--- a/src/components/common/card/ShadowCard.tsx
+++ b/src/components/common/card/ShadowCard.tsx
@@ -10,7 +10,7 @@ export default function ShadowCard({ children, className }: ShadowCardProps) {
   return (
     <div
       className={cn(
-        'cursor-pointer rounded-[20px] p-4 shadow-custom-4px transition-shadow duration-300 hover:shadow-custom-16px active:bg-gray-50',
+        'cursor-pointer rounded-[20px] bg-white p-4 shadow-custom-4px transition-shadow duration-300 hover:shadow-custom-16px active:bg-gray-50',
         className,
       )}>
       {children}

--- a/src/components/domain/user/CirclePlanetIcon.tsx
+++ b/src/components/domain/user/CirclePlanetIcon.tsx
@@ -10,23 +10,21 @@ interface CirclePlanetIconProps {
 }
 
 const CirclePlanetIcon = ({ className, iconIndex }: CirclePlanetIconProps) => {
-  const [randomIndex, setRandomIndex] = useState<number | null>(null);
+  const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
+  const [randomIndex, setRandomIndex] = useState<number>(() =>
+    Math.floor(Math.random() * planetKeys.length),
+  );
 
   useEffect(() => {
     if (iconIndex === undefined) {
-      const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
-      const randomIdx = Math.floor(Math.random() * planetKeys.length);
-      setRandomIndex(randomIdx);
+      setRandomIndex(Math.floor(Math.random() * planetKeys.length));
     }
-  }, [iconIndex]);
+  }, [iconIndex, planetKeys.length]);
 
-  const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
   const PlanetIcon =
     iconIndex !== undefined
       ? PlanetIcons[planetKeys[iconIndex]]
-      : randomIndex !== null
-        ? PlanetIcons[planetKeys[randomIndex]]
-        : null;
+      : PlanetIcons[planetKeys[randomIndex]];
 
   return (
     <div

--- a/src/components/domain/user/CirclePlanetIcon.tsx
+++ b/src/components/domain/user/CirclePlanetIcon.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { useEffect, useState } from 'react';
+import { PlanetIcons } from '@/assets/icon/planet';
+
+interface CirclePlanetIconProps {
+  className?: string;
+  iconIndex?: number;
+}
+
+const CirclePlanetIcon = ({ className, iconIndex }: CirclePlanetIconProps) => {
+  const [randomIndex, setRandomIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (iconIndex === undefined) {
+      const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
+      const randomIdx = Math.floor(Math.random() * planetKeys.length);
+      setRandomIndex(randomIdx);
+    }
+  }, [iconIndex]);
+
+  const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
+  const PlanetIcon =
+    iconIndex !== undefined
+      ? PlanetIcons[planetKeys[iconIndex]]
+      : randomIndex !== null
+        ? PlanetIcons[planetKeys[randomIndex]]
+        : null;
+
+  return (
+    <div
+      className={cn('flex h-[56px] w-[56px] items-center justify-center rounded-full', className)}>
+      {PlanetIcon && <PlanetIcon />}
+    </div>
+  );
+};
+
+export default CirclePlanetIcon;

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import ShadowCard from '@/components/common/card/ShadowCard';
+import TagInput from '@/components/common/input/TagInput';
+import CirclePlanetIcon from './CirclePlanetIcon';
+import { ChevronRight } from 'lucide-react';
+
+export default function UserSummaryCard() {
+  const handleOpenUserProfile = () => {
+    console.log('프로필 보러가기 연결 예정');
+  };
+
+  // NOTE: project API 연동 이후 하드코딩된 값 변경 예정
+
+  return (
+    <ShadowCard className="flex h-[157px] w-[512px] flex-col justify-between p-6">
+      <div className="flex items-start space-x-4">
+        <CirclePlanetIcon className="bg-gray-100" />
+        <div className="flex flex-col justify-center">
+          <p className="body8">이지영</p>
+          <p className="text-gray-500 display5">fj298@gmail.com</p>
+        </div>
+      </div>
+      <div className="mt-auto flex items-center justify-between">
+        <div className="flex items-center">
+          <TagInput value="기획자" buttonType="none" colorTheme="indigo" className="mr-2" />
+          <TagInput value="디자이너" buttonType="none" colorTheme="indigo" />
+        </div>
+        <div
+          className="cursor-pointer text-gray-600 underline decoration-current display5 flex-center"
+          style={{ textUnderlineOffset: '4px' }}
+          onClick={handleOpenUserProfile}>
+          프로필 보러가기
+          <ChevronRight className="h-4 w-4" />
+        </div>
+      </div>
+    </ShadowCard>
+  );
+}

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -22,8 +22,8 @@ export default function UserSummaryCard() {
         </div>
       </div>
       <div className="mt-auto flex items-center justify-between">
-        <div className="flex items-center">
-          <TagInput value="기획자" buttonType="none" colorTheme="indigo" className="mr-2" />
+        <div className="flex items-center gap-2">
+          <TagInput value="기획자" buttonType="none" colorTheme="indigo" />
           <TagInput value="디자이너" buttonType="none" colorTheme="indigo" />
         </div>
         <div

--- a/src/components/domain/user/userProfile/UserProfile.tsx
+++ b/src/components/domain/user/userProfile/UserProfile.tsx
@@ -1,0 +1,38 @@
+import BorderCard from '@/components/common/card/BorderCard';
+import CirclePlanetIcon from '../CirclePlanetIcon';
+
+export default function UserProfile() {
+  // NOTE: api 연동 이후 수정 예정
+  const labels = ['이메일', '관심 직무', '기술 스택'];
+  const items = [
+    'PRism@gmail.com',
+    '디자이너',
+    'Figma, Protipie, Adobe XD, Adobe Photoshop, Figma, Figma, Protipie, Adobe XD, Adobe Photoshop, Figma',
+  ];
+
+  return (
+    <div className="flex w-full">
+      <div className="mr-4 flex h-[165px] w-[248px] flex-col items-center justify-center rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6">
+        <CirclePlanetIcon className="bg-white" />
+        <span className="mt-2.5 text-white">안유경</span>
+      </div>
+      <BorderCard className="flex h-[165px] w-full min-w-0 max-w-[776px] flex-grow space-x-8 overflow-hidden p-8">
+        <div className="flex w-[60px] flex-col space-y-4">
+          {labels.map((label, index) => (
+            <span key={index} className="whitespace-nowrap text-purple-800 display6">
+              {label}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex flex-col space-y-4 overflow-y-auto">
+          {items.map((item, index) => (
+            <span key={index} className="text-gray-500 display4">
+              {item}
+            </span>
+          ))}
+        </div>
+      </BorderCard>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -242,7 +242,7 @@ const config: Config = {
         '.display6': {
           fontSize: '16px',
           fontWeight: '600',
-          lineHeight: '1.2',
+          lineHeight: '1.4',
         },
         '.flex-center': {
           display: 'flex',


### PR DESCRIPTION
## 💡 ISSUE 번호

#62 

<br/>

## 🔎 작업 내용

- `layout` 전체 `gray-50` 적용
- 유저 요약 카드 컴포넌트 생성
- 마이페이지 상단 유저 프로필 컴포넌트 생성
- `CirclePlanetIcon` 컴포넌트 생성
- 마이페이지 초기 스크린 작업

<br/>

## 📢 주의 및 리뷰 요청

- 프로젝트 전체에 배경색을 지정했습니다. 앞으로 컴포넌트에 bg 컬러를 적용해 주어야 합니다.
- 현재 마이페이지 초기 스크린 작업을 해두었는데, GUI 상으로 "타인 프로필"에 해당합니다. 참고해 주세요.
- 기본적인 반응형 처리만 해두었습니다. 
- 기술 스택이 많아지면 스크린이 어떻게 대응되는지 GUI가 없어서 일단 스트롤로 처리해 두었습니다.
- 작업하다 보니 아래 컴포넌트가 많이 사용되는데, 이 아이콘은 가입 시 랜덤 배정되고 고정인 건지, 아니면 렌더링 할 때마다 자유롭게 바뀌어도 되는 건지 잘 모르겠어서 일단 초기 렌더링 시 랜덤 배정되도록 해두었습니다. 사용자마다 고정 아이콘을 설정해 주려면, 회원가입할 때마다 백엔드에서 1~12 값 중 하나를  뿌려달라고 요청드려야 할 것 같은데, 현재 저희 프로젝트에서 중요한 부분은 아니라고 판단됩니다. 다만, 중복으로 사용되어 원형 도형 내 아이콘을 하나의 컴포넌트로 분리하였습니다. (`CirclePlanetIcon`) 프로젝트 등록에서도 사용 가능하지만, 리팩토링은 추후 진행해도 될 것 같습니다.
![Pasted Graphic 1](https://github.com/user-attachments/assets/e5d471b4-816b-4076-96c1-cebf069278de)
- 현재 SVG에 w,h 속성 적용이 안되어서 확인해보니, 아래와 같이 SVG 자체에 `width`와 `height`가 고정으로 들어가 있습니다. <img width="498" src="https://github.com/user-attachments/assets/c103a076-cda0-4a15-8d1f-ce0fd0a96bc5">

- 하지만 GUI에는 `[프로젝트 등록: 26px, 유저 프로필: 40px, 마이페이지 상단: 48px]`로 들어가 있어서 커스텀이 필요한 상황입니다.  변경하려면 `className`으로 감싸고 SVG를 하나하나 컴포넌트화 시켜야 합니다. 
테스트 해보니 가능은 한데, (좌: GUI대로 커스텀 한 버전 / 우: 그대로 사용) 저희 svg 용량이 다른 svg보다 용량이 꽤 큰 편인데다가 12개라서 렌더링 성능이 저하될까봐 걱정이 됩니다. SVGO를 사용하여 SVG 파일을 최적화하고, 이를 컴포넌트화 시키는 방법이 남아있는데, 이 부분은 조금 자료조사가 필요할 것 같습니다. 
![스크린샷 2024-07-19 오전 3 39 37](https://github.com/user-attachments/assets/72bbe4d5-3a87-47f2-a60b-a93aef035252)

---
- 요약: 소은 님께서 전달해주신 SVG파일 자제에 크기가 고정값으로 설정되어 있어 프론트에서 커스텀 불가
- 방법 1: SVG 크기 변경 없이 통일 (중간값…) - **현재 작업 상태**
방법 2: 컴포넌트화 후 커스텀 (SVG 최적화 **추후** 진행)
방법 3: 컴포넌트화 후 커스텀 (SVG 최적화 **지금** 진행….) 
방법 4: 그냥 `png`로 받아서 `webp` 변환하고 이미지로 저장하기
- 보시고 의견 부탁 드립니다!


<br/>

## 🔗 Reference

- [SVGOMG](https://a11y.gitbook.io/graphics-aria/svg-graphics/svg-optimize)
