### PR TITLE
Feat/#33 로그인 상태 global header 조건부 렌더링 및 로그아웃 구현

### DIFF
--- a/src/app/layout/footer/GlobalFooter.tsx
+++ b/src/app/layout/footer/GlobalFooter.tsx
@@ -1,9 +1,18 @@
+import { Mail, Copyright } from 'lucide-react';
+
 export default function GlobalFooter() {
   return (
-    <footer className="bottom-0 h-[80px] w-full py-6 md:py-0">
-      <div className="gap-4 flex-col-center md:h-20 md:flex-row">
-        <p className="text-gray-600 body6">PRism</p>
-        <p className="text-gray-400 display5">©PRism. All rights reserved.</p>
+    <footer className="bottom-0 h-full w-full bg-gray-100 py-6">
+      <div className="flex flex-col items-center gap-2 md:h-20">
+        <p className="text-gray-600 display2">Team PRism.</p>
+        <div className="flex items-center gap-1 text-gray-500 mobile2">
+          <Mail className="h-4 w-4" />
+          Contact Us: swyp5thteam6@gmail.com
+        </div>
+        <div className="flex items-center text-gray-400 display5">
+          <Copyright className="h-3 w-3" />
+          2024. PRism. All rights reserved.
+        </div>
       </div>
     </footer>
   );

--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -20,7 +20,7 @@ import {
   MenubarTrigger,
 } from '@/components/ui/menubar';
 
-const GlobalHeader = () => {
+export default function GlobalHeader() {
   const { openModal, closeModal } = useModalStore();
   const { isLoggedIn } = useAuthStore();
   const logoutMutation = useLogout();
@@ -109,6 +109,4 @@ const GlobalHeader = () => {
       </div>
     </Menubar>
   );
-};
-
-export default GlobalHeader;
+}

--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useModalStore } from '@/stores/modalStore';
-import { useAuthStore } from '@/stores/authStore';
-import { Button } from '@/components/ui/button';
-import { AlignJustify, LogOut } from 'lucide-react';
+import React from 'react';
+import Link from 'next/link';
 import LoginModal from '@/components/domain/auth/login/LoginModal';
 import SignupModal from '@/components/domain/auth/signup/SignupModal';
+import ProjectRegisterModal from '@/components/domain/project/projectRegisterModal/ProjectRegisterModal';
 import PrismLogo from '@/assets/logo/logo-combine.svg';
+import { useModalStore } from '@/stores/modalStore';
+import { useAuthStore } from '@/stores/authStore';
+import { AlignJustify, LogOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import {
   Menubar,
   MenubarContent,
@@ -16,7 +19,7 @@ import {
   MenubarTrigger,
 } from '@/components/ui/menubar';
 
-export default function GlobalHeader() {
+const GlobalHeader = () => {
   const { openModal, closeModal } = useModalStore();
   const { isLoggedIn, logout } = useAuthStore();
 
@@ -40,11 +43,49 @@ export default function GlobalHeader() {
     alert('로그아웃 되었습니다.');
   };
 
+  const handleOpenProject = () => {
+    openModal(<ProjectRegisterModal />);
+  };
+
+  const renderAuthButtons = () => (
+    <>
+      <Button
+        onClick={handleOpenLoginModal}
+        variant="outline"
+        className="border-1 mr-2 border border-gray-700 text-gray-700">
+        로그인
+      </Button>
+      <Button
+        onClick={handleOpenSignupModal}
+        variant="default"
+        className="bg-purple-500 hover:bg-purple-600">
+        회원가입
+      </Button>
+    </>
+  );
+
+  const renderMenuItem = (href: string, label: string, onClick?: () => void) => (
+    <>
+      {onClick ? (
+        <MenubarItem className="cursor-pointer" onClick={onClick}>
+          <span>{label}</span>
+        </MenubarItem>
+      ) : (
+        <Link href={href} passHref legacyBehavior>
+          <MenubarItem className="cursor-pointer">
+            <span>{label}</span>
+          </MenubarItem>
+        </Link>
+      )}
+      <MenubarSeparator />
+    </>
+  );
+
   return (
     <Menubar className="flex h-[70px] w-full items-center justify-between bg-white px-4 py-4 shadow-custom-2px md:px-8 lg:px-24 lg:py-8">
-      <div className="flex items-center">
+      <Link href="/" className="flex items-center">
         <PrismLogo className="w-[150px]" />
-      </div>
+      </Link>
       <div className="flex items-center">
         {isLoggedIn ? (
           <MenubarMenu>
@@ -52,19 +93,9 @@ export default function GlobalHeader() {
               <AlignJustify className="h-7 w-7" />
             </MenubarTrigger>
             <MenubarContent className="m-5">
-              <MenubarSeparator />
-              <MenubarItem className="cursor-pointer">
-                <span>마이페이지</span>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem className="cursor-pointer">
-                <span>새 프로젝트 등록</span>
-              </MenubarItem>
-              <MenubarSeparator />
-              <MenubarItem className="cursor-pointer">
-                <span>프로젝트 관리</span>
-              </MenubarItem>
-              <MenubarSeparator />
+              {renderMenuItem('/mypage', '마이페이지')}
+              {renderMenuItem('', '새 프로젝트 등록', handleOpenProject)}
+              {renderMenuItem('/project/manage', '프로젝트 관리')}
               <MenubarItem className="cursor-pointer" onClick={handleLogout}>
                 <LogOut className="mr-2 h-[16px] w-[16px]" />
                 <span>로그아웃</span>
@@ -72,22 +103,11 @@ export default function GlobalHeader() {
             </MenubarContent>
           </MenubarMenu>
         ) : (
-          <>
-            <Button
-              onClick={handleOpenLoginModal}
-              variant="outline"
-              className="border-1 mr-2 border border-gray-700 text-gray-700">
-              로그인
-            </Button>
-            <Button
-              onClick={handleOpenSignupModal}
-              variant="default"
-              className="bg-purple-500 hover:bg-purple-600">
-              회원가입
-            </Button>
-          </>
+          renderAuthButtons()
         )}
       </div>
     </Menubar>
   );
-}
+};
+
+export default React.memo(GlobalHeader);

--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useModalStore } from '@/stores/modalStore';
+import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/ui/button';
 import { AlignJustify, LogOut } from 'lucide-react';
 import LoginModal from '@/components/domain/auth/login/LoginModal';
@@ -14,7 +15,6 @@ import {
   MenubarSeparator,
   MenubarTrigger,
 } from '@/components/ui/menubar';
-import { useAuthStore } from '@/stores/authStore';
 
 export default function GlobalHeader() {
   const { openModal, closeModal } = useModalStore();
@@ -41,7 +41,7 @@ export default function GlobalHeader() {
   };
 
   return (
-    <Menubar className="flex h-[70px] w-full items-center justify-between bg-white px-24 py-8 shadow-custom-2px">
+    <Menubar className="flex h-[70px] w-full items-center justify-between bg-white px-4 py-4 shadow-custom-2px md:px-8 lg:px-24 lg:py-8">
       <div className="flex items-center">
         <PrismLogo className="w-[150px]" />
       </div>

--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -14,9 +14,11 @@ import {
   MenubarSeparator,
   MenubarTrigger,
 } from '@/components/ui/menubar';
+import { useAuthStore } from '@/stores/authStore';
 
 export default function GlobalHeader() {
   const { openModal, closeModal } = useModalStore();
+  const { isLoggedIn, logout } = useAuthStore();
 
   const handleSignupSuccess = () => {
     closeModal();
@@ -33,50 +35,59 @@ export default function GlobalHeader() {
     openModal(<SignupModal onSuccess={handleSignupSuccess} />);
   };
 
-  // NOTE: 로그인 여부에 따라 토글 조건부 렌더링 로직 추가 예정. 현재 스크린만 진행된 상태
+  const handleLogout = () => {
+    logout();
+    alert('로그아웃 되었습니다.');
+  };
+
   return (
     <Menubar className="flex h-[70px] w-full items-center justify-between bg-white px-24 py-8 shadow-custom-2px">
       <div className="flex items-center">
         <PrismLogo className="w-[150px]" />
       </div>
       <div className="flex items-center">
-        <Button
-          onClick={handleOpenLoginModal}
-          variant="outline"
-          className="border-1 mr-2 border border-gray-700 text-gray-700">
-          로그인
-        </Button>
-        <Button
-          onClick={handleOpenSignupModal}
-          variant="default"
-          className="bg-purple-500 hover:bg-purple-600">
-          회원가입
-        </Button>
+        {isLoggedIn ? (
+          <MenubarMenu>
+            <MenubarTrigger className="ml-auto">
+              <AlignJustify className="h-7 w-7" />
+            </MenubarTrigger>
+            <MenubarContent className="m-5">
+              <MenubarSeparator />
+              <MenubarItem className="cursor-pointer">
+                <span>마이페이지</span>
+              </MenubarItem>
+              <MenubarSeparator />
+              <MenubarItem className="cursor-pointer">
+                <span>새 프로젝트 등록</span>
+              </MenubarItem>
+              <MenubarSeparator />
+              <MenubarItem className="cursor-pointer">
+                <span>프로젝트 관리</span>
+              </MenubarItem>
+              <MenubarSeparator />
+              <MenubarItem className="cursor-pointer" onClick={handleLogout}>
+                <LogOut className="mr-2 h-[16px] w-[16px]" />
+                <span>로그아웃</span>
+              </MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+        ) : (
+          <>
+            <Button
+              onClick={handleOpenLoginModal}
+              variant="outline"
+              className="border-1 mr-2 border border-gray-700 text-gray-700">
+              로그인
+            </Button>
+            <Button
+              onClick={handleOpenSignupModal}
+              variant="default"
+              className="bg-purple-500 hover:bg-purple-600">
+              회원가입
+            </Button>
+          </>
+        )}
       </div>
-      <MenubarMenu>
-        <MenubarTrigger className="ml-auto">
-          <AlignJustify className="h-7 w-7" />
-        </MenubarTrigger>
-        <MenubarContent className="m-5">
-          <MenubarSeparator />
-          <MenubarItem className="cursor-pointer">
-            <span>마이페이지</span>
-          </MenubarItem>
-          <MenubarSeparator />
-          <MenubarItem className="cursor-pointer">
-            <span>새 프로젝트 등록</span>
-          </MenubarItem>
-          <MenubarSeparator />
-          <MenubarItem className="cursor-pointer">
-            <span>프로젝트 관리</span>
-          </MenubarItem>
-          <MenubarSeparator />
-          <MenubarItem className="cursor-pointer">
-            <LogOut className="mr-2 h-[16px] w-[16px]" />
-            <span>로그아웃</span>
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
     </Menubar>
   );
 }

--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -8,6 +8,7 @@ import ProjectRegisterModal from '@/components/domain/project/projectRegisterMod
 import PrismLogo from '@/assets/logo/logo-combine.svg';
 import { useModalStore } from '@/stores/modalStore';
 import { useAuthStore } from '@/stores/authStore';
+import { useLogout } from '@/hooks/queries/useAuthService';
 import { AlignJustify, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -21,7 +22,8 @@ import {
 
 const GlobalHeader = () => {
   const { openModal, closeModal } = useModalStore();
-  const { isLoggedIn, logout } = useAuthStore();
+  const { isLoggedIn } = useAuthStore();
+  const logoutMutation = useLogout();
 
   const handleSignupSuccess = () => {
     closeModal();
@@ -39,8 +41,7 @@ const GlobalHeader = () => {
   };
 
   const handleLogout = () => {
-    logout();
-    alert('로그아웃 되었습니다.');
+    logoutMutation.mutate();
   };
 
   const handleOpenProject = () => {
@@ -110,4 +111,4 @@ const GlobalHeader = () => {
   );
 };
 
-export default React.memo(GlobalHeader);
+export default GlobalHeader;

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { LoginResponse } from '@/models/auth/authApiModels';
+import { LoginResponse, LogoutResponse } from '@/models/auth/authApiModels';
 import { useAuthStore } from '@/stores/authStore';
 import { useModalStore } from '@/stores/modalStore';
 import type { LoginForm } from '@/models/auth/authModels';
-import { login } from '../../services/api/authApi';
+import { login, logout } from '../../services/api/authApi';
 import { useUserStore } from '@/stores/userStore';
 import { userData } from '@/services/api/userApi';
 
@@ -45,6 +45,24 @@ export const useLogin = () => {
     onError: (error) => {
       alert('로그인에 실패했습니다. 다시 시도해 주세요.');
       console.error('로그인 실패: ', error);
+    },
+  });
+};
+
+export const useLogout = () => {
+  const logoutAuthStore = useAuthStore((state) => state.logout);
+  const clearUser = useUserStore((state) => state.clearUser);
+
+  return useMutation<LogoutResponse, AxiosError>({
+    mutationFn: logout,
+    onSuccess: () => {
+      logoutAuthStore();
+      clearUser();
+      alert('로그아웃 되었습니다.');
+    },
+    onError: (error) => {
+      console.error('로그아웃 실패:', error);
+      alert('로그아웃에 실패했습니다. 다시 시도해 주세요.');
     },
   });
 };

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -51,13 +51,11 @@ export const useLogin = () => {
 
 export const useLogout = () => {
   const logoutAuthStore = useAuthStore((state) => state.logout);
-  const clearUser = useUserStore((state) => state.clearUser);
 
   return useMutation<LogoutResponse, AxiosError>({
     mutationFn: logout,
     onSuccess: () => {
       logoutAuthStore();
-      clearUser();
       alert('로그아웃 되었습니다.');
     },
     onError: (error) => {

--- a/src/models/auth/authApiModels.ts
+++ b/src/models/auth/authApiModels.ts
@@ -65,3 +65,9 @@ export interface RefreshTokenResponse {
     refreshToken: string;
   };
 }
+
+export interface LogoutResponse {
+  success: boolean;
+  status: number;
+  data: null;
+}

--- a/src/services/api/authApi.ts
+++ b/src/services/api/authApi.ts
@@ -10,6 +10,7 @@ import {
   VerifyAuthCodeResponse,
   LoginRequest,
   LoginResponse,
+  LogoutResponse,
 } from '@/models/auth/authApiModels';
 
 // NOTE: 개발을 위해 임시로 로그를 많이 추가해두었습니다. 배포 전 삭제할 예정입니다.
@@ -101,5 +102,19 @@ export const login = async (data: LoginRequest): Promise<LoginResponse> => {
     } else {
       throw new Error(`로그인 실패: ${error}`);
     }
+  }
+};
+
+export const logout = async (): Promise<LogoutResponse> => {
+  try {
+    const response = await ax.post<LogoutResponse>('/api/v1/auth/logout');
+    if (response.data.success) {
+      return response.data;
+    } else {
+      throw new Error('로그아웃 실패');
+    }
+  } catch (error) {
+    console.error('로그아웃 실패:', error);
+    throw error;
   }
 };

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist, devtools } from 'zustand/middleware';
+import { useUserStore } from './userStore';
 
 const AUTH_STORE_NAME = 'auth-state';
 
@@ -26,12 +27,15 @@ export const useAuthStore = create<AuthState>()(
             accessToken,
             refreshToken,
           }),
-        logout: () =>
+        logout: () => {
           set({
             isLoggedIn: false,
             accessToken: null,
             refreshToken: null,
-          }),
+          });
+          localStorage.removeItem('auth-state');
+          useUserStore.getState().clearUser();
+        },
         setAccessToken: (newAccessToken) => set({ accessToken: newAccessToken }),
         setRefreshToken: (newRefreshToken) => set({ refreshToken: newRefreshToken }),
       }),

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -33,7 +33,6 @@ export const useAuthStore = create<AuthState>()(
             accessToken: null,
             refreshToken: null,
           });
-          localStorage.removeItem('auth-state');
           useUserStore.getState().clearUser();
         },
         setAccessToken: (newAccessToken) => set({ accessToken: newAccessToken }),

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist, devtools } from 'zustand/middleware';
+import { User } from '@/models/user/userModels';
 
 const USER_STORE_NAME = 'user-state';
 
-import { User } from '@/models/user/userModels';
 interface UserStoreType {
   user: User | null;
   setUser: (user: User) => void;
@@ -17,10 +17,7 @@ export const useUserStore = create<UserStoreType>()(
       (set) => ({
         user: null,
         setUser: (user: User) => set({ user }),
-        clearUser: () => {
-          set({ user: null });
-          localStorage.removeItem('user-state');
-        },
+        clearUser: () => set({ user: null }),
       }),
       {
         name: USER_STORE_NAME,

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -17,7 +17,10 @@ export const useUserStore = create<UserStoreType>()(
       (set) => ({
         user: null,
         setUser: (user: User) => set({ user }),
-        clearUser: () => set({ user: null }),
+        clearUser: () => {
+          set({ user: null });
+          localStorage.removeItem('user-state');
+        },
       }),
       {
         name: USER_STORE_NAME,


### PR DESCRIPTION
## 💡 ISSUE 번호

#33 

<br/>

## 🔎 작업 내용

- 로그인 상태에 따른 조건부 렌더링 로직 추가
- 로그아웃 시 `localStorage`에서 사용자 정보 제거
- 페이지 이동 로직 추가
- 헤더 반응형 처리 추가
- `GlobalFooter` UI 수정

<br/>

## 📢 주의 및 리뷰 요청

- 백엔드에서 로그아웃 시 사용자 정보를 모두 제거해달라고 하셔서 관련 로직을 추가하였습니다. 
- 권한에 따라 조건부 렌더링 로직을 추가하면서 반응형 처리도 어느 정도 해두었습니다. 
- 프로젝트 관리 메뉴도 저희가 논의했던 url로 설정해두었습니다. (현재는 페이지가 없어서 404로 뜹니다.)
- `GlobalFooter` UI를 수정했습니다. 피그마 GUI와 다르니 참고해 주세요.
![스크린샷 2024-07-20 오후 9 32 40](https://github.com/user-attachments/assets/234191a0-7a33-4c83-8389-55f3b9bcabd0)

<br/>

## 🔗 Reference

- [푸터 디자인 패턴](https://slowalk.com/2592)
- [올바른 저작권 표기방법 (Copyright 표기)](https://m.blog.naver.com/jinee0701/222630449671)