### PR TITLE
Feat/#52 Radial Chart 추가 (추가 지표 차트), 마이페이지 스크린 작업

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,7 +1,9 @@
 import BorderCard from '@/components/common/card/BorderCard';
-import ProjectSummaryCard from '@/components/domain/project/projectCard/ProjectSummaryCard';
+import ProjectSummaryCard, {
+  PROJECT_CARD_VARIANT,
+} from '@/components/domain/project/projectCard/ProjectSummaryCard';
 import UserProfile from '@/components/domain/user/userProfile/UserProfile';
-import { PROJECT_CARD_VARIANT, type ProjectSummaryData } from '@/models/project/projectModels';
+import { type ProjectSummaryData } from '@/models/project/projectModels';
 
 export default function MyPage() {
   // 예시로 데이터 넣어놨습니다. 추후 수정 부탁드립니다!

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -116,7 +116,7 @@ export default function MyPage() {
       <section className="flex flex-col gap-4">
         <div className="flex items-center gap-1">
           <h2 className="text-gray-900 body6">프로젝트 목록</h2>
-          <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시되요." />
+          <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시돼요." />
         </div>
         {projectDatas.length === 0 ? (
           <BorderCard className="h-[165px] w-full flex-col-center">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,37 @@
 import BorderCard from '@/components/common/card/BorderCard';
+import PRismChart, { Evaluation } from '@/components/common/chart/PRismChart';
+import RadialChart from '@/components/common/chart/RadialChart';
+import TagInput from '@/components/common/input/TagInput';
+import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 import ProjectSummaryCard from '@/components/domain/project/projectCard/ProjectSummaryCard';
 import UserProfile from '@/components/domain/user/userProfile/UserProfile';
+import { RADIAL_EVALUATION_TYPES } from '@/models/evaluation/evaluationModels';
 import { PROJECT_CARD_VARIANT, type ProjectSummaryData } from '@/models/project/projectModels';
 
 export default function MyPage() {
   // 예시로 데이터 넣어놨습니다. 추후 수정 부탁드립니다!
+  const chartData: Evaluation[] = [
+    {
+      evaluation: 'COMMUNICATION',
+      percent: 60,
+    },
+    {
+      evaluation: 'PROACTIVITY',
+      percent: 50,
+    },
+    {
+      evaluation: 'PROBLEM_SOLVING',
+      percent: 70,
+    },
+    {
+      evaluation: 'RESPONSIBILITY',
+      percent: 80,
+    },
+    {
+      evaluation: 'COOPERATION',
+      percent: 90,
+    },
+  ];
   const projectDatas: ProjectSummaryData[] = [
     {
       projectId: 1,
@@ -33,15 +60,64 @@ export default function MyPage() {
       projectVisibility: false,
     },
   ];
+
+  const prismTextData = [
+    { label: '키워드', value: ['배려', '책임감', '도전정신'] },
+    {
+      label: '한 줄 요약',
+      value:
+        '문제점을 바로 파악하고 해결책을 생각하는 문제해결능력이 큰 장점인 사람니다. 다만 진행상황에 대해 즉시 공유하는 팀워크 능력이 다소 부족하다.',
+    },
+  ];
+
   return (
-    <main className="container mx-auto flex min-h-screen flex-col items-center p-12">
-      <div className="flex w-full justify-end" style={{ width: '90%' }}></div>
-      <div className="flex w-full max-w-[1040px] flex-col gap-4">
-        <span className="text-gray-900 body6">사용자 프로필</span>
+    <main className="container flex min-h-screen w-full max-w-[1040px] flex-col justify-center gap-5 p-4">
+      <section className="flex flex-col gap-4">
+        <h2 className="text-gray-900 body6">프로필</h2>
         <UserProfile />
-      </div>
-      <div className="mt-8 flex w-full max-w-[1040px] flex-col gap-4">
-        <span className="text-gray-900 body6">프로젝트 목록 </span>
+      </section>
+      <section className="flex flex-col gap-4">
+        <h2 className="text-gray-900 body6">PRism 분석 리포트</h2>
+        <BorderCard className="flex-wrap gap-8 flex-center">
+          <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
+            <div className="text-indigo-800 body6">나의 PRism</div>
+            <div className="h-full w-full">
+              <PRismChart data={chartData} />
+            </div>
+          </div>
+          <div className="flex h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
+            <div className="text-indigo-800 body6">나의 PRism 분석 리포트</div>
+            <div className="gap-3 flex-col-center">
+              <div className="flex-center">
+                <RadialChart type={RADIAL_EVALUATION_TYPES.LEADERSHIP} value={70} />
+                <RadialChart type={RADIAL_EVALUATION_TYPES.RELIABILITY} value={80} />
+                <RadialChart type={RADIAL_EVALUATION_TYPES.CHARISMA} value={50} />
+              </div>
+              <div className="grid grid-cols-[80px_1fr] gap-x-2 gap-y-2">
+                {prismTextData.map((item, index) => (
+                  <div key={index} className="contents">
+                    <div className="flex text-gray-400 mobile1">{item.label}</div>
+                    <div className="flex gap-1 text-gray-800 display5">
+                      {!item.value
+                        ? '-'
+                        : item.label === '키워드' && Array.isArray(item.value)
+                          ? item.value.map((value, index) => (
+                              <TagInput key={index} value={value} isDisabled />
+                            ))
+                          : item.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </BorderCard>
+      </section>
+      <section className="flex flex-col gap-4">
+        <div className="flex items-center gap-1">
+          <h2 className="text-gray-900 body6">프로젝트 목록</h2>
+          <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시되요." />
+        </div>
         {projectDatas.length === 0 ? (
           <BorderCard className="h-[165px] w-full flex-col-center">
             <span className="text-gray-600 display6">등록된 프로젝트가 없습니다.</span>
@@ -58,7 +134,7 @@ export default function MyPage() {
             ))}
           </ul>
         )}
-      </div>
+      </section>
     </main>
   );
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,9 +1,7 @@
 import BorderCard from '@/components/common/card/BorderCard';
-import ProjectSummaryCard, {
-  PROJECT_CARD_VARIANT,
-} from '@/components/domain/project/projectCard/ProjectSummaryCard';
+import ProjectSummaryCard from '@/components/domain/project/projectCard/ProjectSummaryCard';
 import UserProfile from '@/components/domain/user/userProfile/UserProfile';
-import { type ProjectSummaryData } from '@/models/project/projectModels';
+import { PROJECT_CARD_VARIANT, type ProjectSummaryData } from '@/models/project/projectModels';
 
 export default function MyPage() {
   // 예시로 데이터 넣어놨습니다. 추후 수정 부탁드립니다!

--- a/src/components/common/chart/PRismChart.tsx
+++ b/src/components/common/chart/PRismChart.tsx
@@ -5,17 +5,9 @@ import { Flag, Puzzle, Users, Wand2, Wrench } from 'lucide-react';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
+import { PRISM_EVALUATIONS, type PRismEvaluationType } from '@/models/evaluation/evaluationModels';
 
-const EVALUATIONS = [
-  'COMMUNICATION',
-  'PROACTIVITY',
-  'PROBLEM_SOLVING',
-  'RESPONSIBILITY',
-  'COOPERATION',
-] as const;
-type EvaluationType = (typeof EVALUATIONS)[number];
-
-const EVALUATION_LABELS: Record<EvaluationType, string> = {
+const EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
   COMMUNICATION: '의사소통능력',
   PROACTIVITY: '적극성',
   PROBLEM_SOLVING: '문제해결능력',
@@ -24,7 +16,7 @@ const EVALUATION_LABELS: Record<EvaluationType, string> = {
 };
 
 export interface Evaluation {
-  evaluation: EvaluationType;
+  evaluation: PRismEvaluationType;
   percent: number;
 }
 
@@ -92,12 +84,12 @@ interface CustomAxisTickProps {
   x?: number;
   y?: number;
   payload?: {
-    value: EvaluationType;
+    value: PRismEvaluationType;
   };
   fontSize?: number;
 }
 
-const ICONS: Record<EvaluationType, React.ElementType> = {
+const ICONS: Record<PRismEvaluationType, React.ElementType> = {
   COMMUNICATION: Users,
   PROACTIVITY: Wand2,
   PROBLEM_SOLVING: Wrench,
@@ -108,9 +100,9 @@ const ICONS: Record<EvaluationType, React.ElementType> = {
 const CustomAxisTick = ({ x, y, payload, fontSize = 14 }: CustomAxisTickProps) => {
   if (!payload || !payload.value) return null;
 
-  const index = EVALUATIONS.indexOf(payload.value);
-  const angle = (Math.PI * 2 * index) / EVALUATIONS.length - Math.PI / 2;
-  const radius = 20;
+  const index = PRISM_EVALUATIONS.indexOf(payload.value);
+  const angle = (Math.PI * 2 * index) / PRISM_EVALUATIONS.length - Math.PI / 2;
+  const radius = 15;
 
   const adjustedX = (x || 0) + Math.cos(angle) * radius;
   const adjustedY = (y || 0) + Math.sin(angle) * radius;

--- a/src/components/common/chart/RadialChart.tsx
+++ b/src/components/common/chart/RadialChart.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Crown, HeartHandshake, Gem } from 'lucide-react';
+import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
+import tailwindColors from 'tailwindcss/colors';
+
+// 평가 유형 상수 및 관련 정보 정의
+export const EVALUATION_TYPES = {
+  LEADERSHIP: 'LEADERSHIP',
+  RELIABILITY: 'RELIABILITY',
+  CHARISMA: 'CHARISMA',
+} as const;
+
+export type EvaluationType = (typeof EVALUATION_TYPES)[keyof typeof EVALUATION_TYPES];
+
+// tailwindColor를 import하면 hydration 오류나서 테일윈드 컬러 팔레트 접근 안하고 색 직접 정의
+export const EVALUATION_INFO: Record<
+  EvaluationType,
+  {
+    label: string;
+    icon: React.ElementType;
+    color: string;
+  }
+> = {
+  [EVALUATION_TYPES.LEADERSHIP]: {
+    label: '리더십',
+    icon: Crown,
+    color: tailwindColors.purple[900],
+  },
+  [EVALUATION_TYPES.RELIABILITY]: {
+    label: '신뢰도',
+    icon: HeartHandshake,
+    color: tailwindColors.purple[800],
+  },
+  [EVALUATION_TYPES.CHARISMA]: {
+    label: '매력도',
+    icon: Gem,
+    color: tailwindColors.purple[900],
+  },
+};
+
+interface RadialChartProps {
+  type: EvaluationType;
+  value: number;
+}
+
+// RadialChart 컴포넌트
+export default function RadialChart({ type, value }: RadialChartProps) {
+  const { label, icon: Icon, color } = EVALUATION_INFO[type];
+
+  // 차트 로드 시, hydration 오류로 마운트 되었을 때만 렌더링 되도록 처리
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+  if (!isMounted) {
+    return null;
+  }
+  return (
+    <div className="relative h-[160px] w-[160px]">
+      <RadialBarChart
+        width={160}
+        height={160}
+        innerRadius="72%"
+        outerRadius="100%"
+        data={[{ value }]}
+        startAngle={90}
+        endAngle={-270}>
+        <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+        <RadialBar background dataKey="value" cornerRadius={50} fill={color} />
+      </RadialBarChart>
+      <div className="absolute inset-0 flex-col-center">
+        <Icon className="h-5 w-5" />
+        {/* figma 기준 mobile2, body2인데, line-height 속성으로 인해 디자인처럼 나올 수 없고 디자인과 너무 상이하여 직접 정의했습니다. */}
+        <span className="text-[12px] font-medium text-gray-400">{label}</span>
+
+        <span className="text-[23px] font-semibold leading-[1] text-indigo-600">{value}%</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/chart/RadialChart.tsx
+++ b/src/components/common/chart/RadialChart.tsx
@@ -4,36 +4,30 @@ import React, { useEffect, useState } from 'react';
 import { Crown, HeartHandshake, Gem } from 'lucide-react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
+import {
+  RADIAL_EVALUATION_TYPES,
+  type RadialEvaluationType,
+} from '@/models/evaluation/evaluationModels';
 
-// 평가 유형 상수 및 관련 정보 정의
-export const EVALUATION_TYPES = {
-  LEADERSHIP: 'LEADERSHIP',
-  RELIABILITY: 'RELIABILITY',
-  CHARISMA: 'CHARISMA',
-} as const;
-
-export type EvaluationType = (typeof EVALUATION_TYPES)[keyof typeof EVALUATION_TYPES];
-
-// tailwindColor를 import하면 hydration 오류나서 테일윈드 컬러 팔레트 접근 안하고 색 직접 정의
 export const EVALUATION_INFO: Record<
-  EvaluationType,
+  RadialEvaluationType,
   {
     label: string;
     icon: React.ElementType;
     color: string;
   }
 > = {
-  [EVALUATION_TYPES.LEADERSHIP]: {
+  [RADIAL_EVALUATION_TYPES.LEADERSHIP]: {
     label: '리더십',
     icon: Crown,
     color: tailwindColors.purple[900],
   },
-  [EVALUATION_TYPES.RELIABILITY]: {
+  [RADIAL_EVALUATION_TYPES.RELIABILITY]: {
     label: '신뢰도',
     icon: HeartHandshake,
     color: tailwindColors.purple[800],
   },
-  [EVALUATION_TYPES.CHARISMA]: {
+  [RADIAL_EVALUATION_TYPES.CHARISMA]: {
     label: '매력도',
     icon: Gem,
     color: tailwindColors.purple[900],
@@ -41,7 +35,7 @@ export const EVALUATION_INFO: Record<
 };
 
 interface RadialChartProps {
-  type: EvaluationType;
+  type: RadialEvaluationType;
   value: number;
 }
 

--- a/src/components/common/tooltip/InformationTooltip.tsx
+++ b/src/components/common/tooltip/InformationTooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AlertCircle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -11,20 +11,12 @@ import ProjectEditDeleteButton from '../projectButton/ProjectEditDeleteButton';
 import ProjectEvaluationButton from '../projectButton/ProjectEvaluationButton';
 import ProjectSendEvaluationLink from '../projectButton/ProjectSendEvaluationLink';
 
-import { type ProjectSummaryData } from '@/models/project/projectModels';
+import {
+  PROJECT_CARD_VARIANT,
+  type ProjectSummaryCardVariant,
+  type ProjectSummaryData,
+} from '@/models/project/projectModels';
 import { formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
-
-// 프로젝트 요약 카드 variant
-export const PROJECT_CARD_VARIANT = {
-  ADMIN: 'Admin', // 관리자 모드에서 내가 등록한 프로젝트 요약 조회
-  LINK_PREVIEW: 'LinkPreview', // 내 프로필에서 조회되는 내가 참여한 프로젝트 요약
-  MY_PROFILE: 'MyProfile', // 프로젝트 연동을 위해 조회할 때 사용
-  OTHER_PROFILE: 'OtherProfile', // 다른 사용자의 프로필에서 프로젝트 조회 시 사용
-  SEARCH_RESULT: 'SearchResult', // 홈 검색에서 프로젝트 검색 결과 표시 시 사용
-} as const;
-
-export type ProjectSummaryCardVariant =
-  (typeof PROJECT_CARD_VARIANT)[keyof typeof PROJECT_CARD_VARIANT];
 
 interface ProjectSummaryCardProps {
   projectData: ProjectSummaryData;

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -11,12 +11,20 @@ import ProjectEditDeleteButton from '../projectButton/ProjectEditDeleteButton';
 import ProjectEvaluationButton from '../projectButton/ProjectEvaluationButton';
 import ProjectSendEvaluationLink from '../projectButton/ProjectSendEvaluationLink';
 
-import {
-  PROJECT_CARD_VARIANT,
-  type ProjectSummaryCardVariant,
-  type ProjectSummaryData,
-} from '@/models/project/projectModels';
+import { type ProjectSummaryData } from '@/models/project/projectModels';
 import { formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
+
+// 프로젝트 요약 카드 variant
+export const PROJECT_CARD_VARIANT = {
+  ADMIN: 'Admin', // 관리자 모드에서 내가 등록한 프로젝트 요약 조회
+  LINK_PREVIEW: 'LinkPreview', // 내 프로필에서 조회되는 내가 참여한 프로젝트 요약
+  MY_PROFILE: 'MyProfile', // 프로젝트 연동을 위해 조회할 때 사용
+  OTHER_PROFILE: 'OtherProfile', // 다른 사용자의 프로필에서 프로젝트 조회 시 사용
+  SEARCH_RESULT: 'SearchResult', // 홈 검색에서 프로젝트 검색 결과 표시 시 사용
+} as const;
+
+export type ProjectSummaryCardVariant =
+  (typeof PROJECT_CARD_VARIANT)[keyof typeof PROJECT_CARD_VARIANT];
 
 interface ProjectSummaryCardProps {
   projectData: ProjectSummaryData;

--- a/src/components/domain/user/CirclePlanetIcon.tsx
+++ b/src/components/domain/user/CirclePlanetIcon.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { PlanetIcons } from '@/assets/icon/planet';
+import { ComponentSpinner } from '@/components/common/spinner';
 
 interface CirclePlanetIconProps {
   className?: string;
@@ -11,20 +12,33 @@ interface CirclePlanetIconProps {
 
 const CirclePlanetIcon = ({ className, iconIndex }: CirclePlanetIconProps) => {
   const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
-  const [randomIndex, setRandomIndex] = useState<number>(() =>
-    Math.floor(Math.random() * planetKeys.length),
-  );
+  const [randomIndex, setRandomIndex] = useState<number | null>(null);
+
+  // hydration 오류로, 마운트 된 경우에만 아이콘 접근하도록 수정
+  const [isMounted, setIsMounted] = useState<boolean>(false);
 
   useEffect(() => {
+    setIsMounted(true);
     if (iconIndex === undefined) {
       setRandomIndex(Math.floor(Math.random() * planetKeys.length));
     }
   }, [iconIndex, planetKeys.length]);
 
+  if (!isMounted) {
+    // 로딩 상태 표시
+    return (
+      <div className="h-[56px] w-[56px] flex-center">
+        <ComponentSpinner />
+      </div>
+    );
+  }
+
   const PlanetIcon =
     iconIndex !== undefined
       ? PlanetIcons[planetKeys[iconIndex]]
-      : PlanetIcons[planetKeys[randomIndex]];
+      : randomIndex !== null
+        ? PlanetIcons[planetKeys[randomIndex]]
+        : null;
 
   return (
     <div

--- a/src/components/domain/user/userProfile/UserProfile.tsx
+++ b/src/components/domain/user/userProfile/UserProfile.tsx
@@ -1,38 +1,42 @@
+'use client';
+
+import { useUserStore } from '@/stores/userStore';
 import BorderCard from '@/components/common/card/BorderCard';
 import CirclePlanetIcon from '../CirclePlanetIcon';
 
 export default function UserProfile() {
   // NOTE: api 연동 이후 수정 예정
-  const labels = ['이메일', '관심 직무', '기술 스택'];
-  const items = [
-    'PRism@gmail.com',
-    '디자이너',
-    'Figma, Protipie, Adobe XD, Adobe Photoshop, Figma, Figma, Protipie, Adobe XD, Adobe Photoshop, Figma',
+
+  const userData = useUserStore((state) => state.user);
+
+  const profileData = [
+    { label: '이메일', value: userData?.email },
+    {
+      label: '관심 직무',
+      value: userData?.roles.join(', '),
+    },
+    {
+      label: '기술 스택',
+      value: userData?.skills.join(', '),
+    },
   ];
 
   return (
-    <div className="flex w-full">
-      <div className="mr-4 flex h-[165px] w-[248px] flex-col items-center justify-center rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6">
+    <section className="flex w-full">
+      <div className="mr-4 flex w-[248px] flex-col items-center justify-center rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6">
         <CirclePlanetIcon className="bg-white" />
         <span className="mt-2.5 text-white">안유경</span>
       </div>
-      <BorderCard className="flex h-[165px] w-full min-w-0 max-w-[776px] flex-grow space-x-8 overflow-hidden p-8">
-        <div className="flex w-[60px] flex-col space-y-4">
-          {labels.map((label, index) => (
-            <span key={index} className="whitespace-nowrap text-purple-800 display6">
-              {label}
-            </span>
-          ))}
-        </div>
-
-        <div className="flex flex-col space-y-4 overflow-y-auto">
-          {items.map((item, index) => (
-            <span key={index} className="text-gray-500 display4">
-              {item}
-            </span>
+      <BorderCard className="flex w-full min-w-0 max-w-[776px] flex-grow overflow-hidden p-8">
+        <div className="grid grid-cols-[100px_1fr] gap-x-4 gap-y-2">
+          {profileData.map((item, index) => (
+            <div key={index} className="contents">
+              <div className="text-purple-700 display6">{item.label}</div>
+              <div className="flex min-h-[30px] text-gray-700 display4">{item.value || '-'}</div>
+            </div>
           ))}
         </div>
       </BorderCard>
-    </div>
+    </section>
   );
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import * as React from 'react';
+import * as RechartsPrimitive from 'recharts';
+
+import { cn } from '@/lib/utils';
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: '', dark: '.dark' } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error('useChart must be used within a <ChartContainer />');
+  }
+
+  return context;
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & {
+    config: ChartConfig;
+    children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children'];
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className,
+        )}
+        {...props}>
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+});
+ChartContainer.displayName = 'Chart';
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(([, config]) => config.theme || config.color);
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join('\n')}
+}
+`,
+          )
+          .join('\n'),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<'div'> & {
+      hideLabel?: boolean;
+      hideIndicator?: boolean;
+      indicator?: 'line' | 'dot' | 'dashed';
+      nameKey?: string;
+      labelKey?: string;
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = 'dot',
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref,
+  ) => {
+    const { config } = useChart();
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null;
+      }
+
+      const [item] = payload;
+      const key = `${labelKey || item.dataKey || item.name || 'value'}`;
+      const itemConfig = getPayloadConfigFromPayload(config, item, key);
+      const value =
+        !labelKey && typeof label === 'string'
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label;
+
+      if (labelFormatter) {
+        return (
+          <div className={cn('font-medium', labelClassName)}>{labelFormatter(value, payload)}</div>
+        );
+      }
+
+      if (!value) {
+        return null;
+      }
+
+      return <div className={cn('font-medium', labelClassName)}>{value}</div>;
+    }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+    if (!active || !payload?.length) {
+      return null;
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== 'dot';
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
+          className,
+        )}>
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || 'value'}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color || item.payload.fill || item.color;
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
+                  indicator === 'dot' && 'items-center',
+                )}>
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            'shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]',
+                            {
+                              'h-2.5 w-2.5': indicator === 'dot',
+                              'w-1': indicator === 'line',
+                              'w-0 border-[1.5px] border-dashed bg-transparent':
+                                indicator === 'dashed',
+                              'my-0.5': nestLabel && indicator === 'dashed',
+                            },
+                          )}
+                          style={
+                            {
+                              '--color-bg': indicatorColor,
+                              '--color-border': indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        'flex flex-1 justify-between leading-none',
+                        nestLabel ? 'items-end' : 'items-center',
+                      )}>
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
+ChartTooltipContent.displayName = 'ChartTooltip';
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> &
+    Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+      hideIcon?: boolean;
+      nameKey?: string;
+    }
+>(({ className, hideIcon = false, payload, verticalAlign = 'bottom', nameKey }, ref) => {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'flex items-center justify-center gap-4',
+        verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+        className,
+      )}>
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || 'value'}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              'flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground',
+            )}>
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+ChartLegendContent.displayName = 'ChartLegend';
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
+  ) {
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+};

--- a/src/models/evaluation/evaluationModels.ts
+++ b/src/models/evaluation/evaluationModels.ts
@@ -1,0 +1,19 @@
+// 추가 평가 유형 상수 및 관련 정보 정의
+export const RADIAL_EVALUATION_TYPES = {
+  LEADERSHIP: 'LEADERSHIP',
+  RELIABILITY: 'RELIABILITY',
+  CHARISMA: 'CHARISMA',
+} as const;
+
+export type RadialEvaluationType =
+  (typeof RADIAL_EVALUATION_TYPES)[keyof typeof RADIAL_EVALUATION_TYPES];
+
+// PRism 평가 유형 상수 및 관련 정보 정의
+export const PRISM_EVALUATIONS = [
+  'COMMUNICATION',
+  'PROACTIVITY',
+  'PROBLEM_SOLVING',
+  'RESPONSIBILITY',
+  'COOPERATION',
+] as const;
+export type PRismEvaluationType = (typeof PRISM_EVALUATIONS)[number];

--- a/src/models/project/projectModels.ts
+++ b/src/models/project/projectModels.ts
@@ -56,7 +56,7 @@ export interface ProjectSummaryData {
   evaluatedMembersCount?: number;
 }
 
-// 프로젝트 요약 카드 variant
+// 프로젝트 요약 카드 variant (ProjectSummaryCard 안으로 옮기려했으나, 번들링 오류로 위치 유지)
 export const PROJECT_CARD_VARIANT = {
   ADMIN: 'Admin', // 관리자 모드에서 내가 등록한 프로젝트 요약 조회
   LINK_PREVIEW: 'LinkPreview', // 내 프로필에서 조회되는 내가 참여한 프로젝트 요약

--- a/src/models/project/projectModels.ts
+++ b/src/models/project/projectModels.ts
@@ -43,7 +43,7 @@ export type ProjectForm = Omit<z.infer<typeof ProjectFormSchema>, 'startDate' | 
   endDate: Date | null;
 };
 
-// 프로젝트 요약 카드에 쓰이는 interface, 추후 작업 진행에 따라 분리되거나 변동될 가능성 있음.
+// 프로젝트 요약 카드에 쓰이는 interface
 export interface ProjectSummaryData {
   projectId: number;
   projectname: string;
@@ -55,3 +55,15 @@ export interface ProjectSummaryData {
   projectVisibility?: boolean;
   evaluatedMembersCount?: number;
 }
+
+// 프로젝트 요약 카드 variant
+export const PROJECT_CARD_VARIANT = {
+  ADMIN: 'Admin', // 관리자 모드에서 내가 등록한 프로젝트 요약 조회
+  LINK_PREVIEW: 'LinkPreview', // 내 프로필에서 조회되는 내가 참여한 프로젝트 요약
+  MY_PROFILE: 'MyProfile', // 프로젝트 연동을 위해 조회할 때 사용
+  OTHER_PROFILE: 'OtherProfile', // 다른 사용자의 프로필에서 프로젝트 조회 시 사용
+  SEARCH_RESULT: 'SearchResult', // 홈 검색에서 프로젝트 검색 결과 표시 시 사용
+} as const;
+
+export type ProjectSummaryCardVariant =
+  (typeof PROJECT_CARD_VARIANT)[keyof typeof PROJECT_CARD_VARIANT];

--- a/src/models/project/projectModels.ts
+++ b/src/models/project/projectModels.ts
@@ -43,7 +43,7 @@ export type ProjectForm = Omit<z.infer<typeof ProjectFormSchema>, 'startDate' | 
   endDate: Date | null;
 };
 
-// 프로젝트 요약 카드에 쓰이는 interface
+// 프로젝트 요약 카드에 쓰이는 interface, 추후 작업 진행에 따라 분리되거나 변동될 가능성 있음.
 export interface ProjectSummaryData {
   projectId: number;
   projectname: string;
@@ -55,15 +55,3 @@ export interface ProjectSummaryData {
   projectVisibility?: boolean;
   evaluatedMembersCount?: number;
 }
-
-// 프로젝트 요약 카드 variant
-export const PROJECT_CARD_VARIANT = {
-  ADMIN: 'Admin', // 관리자 모드에서 내가 등록한 프로젝트 요약 조회
-  LINK_PREVIEW: 'LinkPreview', // 내 프로필에서 조회되는 내가 참여한 프로젝트 요약
-  MY_PROFILE: 'MyProfile', // 프로젝트 연동을 위해 조회할 때 사용
-  OTHER_PROFILE: 'OtherProfile', // 다른 사용자의 프로필에서 프로젝트 조회 시 사용
-  SEARCH_RESULT: 'SearchResult', // 홈 검색에서 프로젝트 검색 결과 표시 시 사용
-} as const;
-
-export type ProjectSummaryCardVariant =
-  (typeof PROJECT_CARD_VARIANT)[keyof typeof PROJECT_CARD_VARIANT];


### PR DESCRIPTION
## 💡 ISSUE 번호

#52 

<br/>

## 🔎 작업 내용

- PRismChart 커스터마이징
- RadialChart 추가 및 커스터마이징
- shadcn/ui chart 추가 (PRism 툴팁에 사용)
- 마이페이지 스크린 수정 및 추가 작업, 차트 적용 (동영상은 용량이 커 슬랙으로 전달드렸습니다.) 
- 마이페이지의 UserProfile 컴포넌트 내용 길어졌을 때 처리 -> 우선 적당히 반응형으로 처리했는데, 보시고 의견 부탁드려용
- CirclePlanetIcon 에서 서버 쪽 렌더링 진행 시 오류가 발생하고 있어, 클라이언트 렌더링 체크 넣고 렌더링 전까지 ComponentSpinner 가 표시되게 수정  (동영상은 용량이 커 슬랙으로 전달드렸습니다.)

<br/>

## 📢 주의 및 리뷰 요청

- 서버컴포넌트에서 클라이언트 컴포넌트의 상수를 import 시 hydration 오류가 나서, 모델쪽 파일로 상수를 옮기거나 mount가 되었는지 상태값으로 판단해 문제를 해결했습니다. 이에 evaluation 이라는 관심사를 하나 추가해 evaluationModels에 넣었습니다. 나중에 설문지 작업하시면서 타입 관리는 해당 파일에서 해주시면 될 것 같습니다.

- 마이페이지에서 작업 못한 것 : 프리즘 없을 때 disabled 처리 (블러 처리), '프로필 수정' 버튼
- 디자인을 전체적으로 확인해보니 BorderCard의 우측 상단에 '프로필 수정', '이미지 저장' 등 버튼이 하나 붙는 것 같습니다. 다음 작업 때 BorderCard의 우측 상단 위치에 prop으로 넘겨받은 클릭 이벤트를 실행시켜주는 absolute 포지션의 버튼을 하나 추가해도 될 것 같습니다.

- 마이페이지에서 프리즘 영역, 프로젝트 리스트를 담당하는 컴포넌트를 분리하고싶었는데, 일단 한곳에 다 넣었습니다. 프리즘 영역은 나중에 근데 무조건 재사용될 것 같아 위치는 나중에 고민해보도록 하겠습니다. (뭔가 타인의 프로필 상세조회 때도 저 프리즘 모양을 쓸 것 같아용 ,, 피그마 보셨을수도있지만 지금 디자인이 좀 바뀔 여지가 많습니다.. 타인 프로필 조회 때는 '한줄 요약' 과 '한줄 평가' 의 구분이 없음..)

**참고**
저는 다음 작업으로 프로젝트 관리자 페이지, 프로젝트 삭제, 프로젝트 수정 구현할 예정입니다. (일요일 내료 완료 목표)

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
