### PR TITLE
Refactor/#74 UserProfileData, UserData 분리

### DIFF
--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -19,6 +19,7 @@ import {
   MenubarSeparator,
   MenubarTrigger,
 } from '@/components/ui/menubar';
+import { PageSpinner } from '@/components/common/spinner';
 
 export default function GlobalHeader() {
   const { openModal, closeModal } = useModalStore();
@@ -107,6 +108,7 @@ export default function GlobalHeader() {
           renderAuthButtons()
         )}
       </div>
+      {logoutMutation.isPending && <PageSpinner />}
     </Menubar>
   );
 }

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -2,16 +2,21 @@
 
 import { useEffect, useState } from 'react';
 import { useModalStore } from '@/stores/modalStore';
-import { useUpdateProfile, useUserData } from '@/hooks/queries/useUserService';
+import { useUserProfileByUserId, useUpdateProfile } from '@/hooks/queries/useUserService';
 import { TechStacks, UserRoles } from '@/lib/tagList';
 import { PageSpinner } from '@/components/common/spinner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import SelectTagModalLayout from '@/components/common/modal/SelectTagModalLayout';
 import TagInput from '@/components/common/input/TagInput';
+import { useUserStore } from '@/stores/userStore';
+import MoveBackButton from '@/components/common/button/MoveBackButton';
 
+// 로그인 한 사용자의 프로필 수정 페이지
 export default function EditMyPage() {
-  const { data: user, isLoading, isError, error } = useUserData();
+  const userId = useUserStore((state) => state.user?.userId);
+
+  const { data: user, isLoading, isError, error } = useUserProfileByUserId(userId || '');
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -37,7 +42,7 @@ export default function EditMyPage() {
   const handleOpenSelectInterestJobsModal = () => {
     openModal(
       <SelectTagModalLayout
-        title="역할 검색"
+        title="관심 직무 검색"
         colorTheme="gray"
         placeholder="관심 직무를 선택해 주세요."
         tagList={UserRoles}
@@ -77,13 +82,13 @@ export default function EditMyPage() {
   };
 
   const handleSubmit = () => {
-    const profileData = {
+    const newProfileData = {
       username: name,
       skills,
       interestJobs,
-      introduction: '',
+      introduction: '', // #20240721.syjang, 기획에 없는 데이터. 백엔드 확인 필요
     };
-    updateProfileMutation.mutate(profileData);
+    updateProfileMutation.mutate(newProfileData);
   };
 
   const renderTags = (tags: string[], type: 'interestJobs' | 'skills', onOpenModal: () => void) => (
@@ -141,19 +146,14 @@ export default function EditMyPage() {
               <span className="text-gray-600 mobile1">보유 스킬</span>
               {renderTags(skills, 'skills', handleOpenSkillsModal)}
             </div>
-            <div className="flex justify-center gap-4">
+            <div className="flex justify-center gap-2">
+              <MoveBackButton className="w-[72px]" />
               <Button
-                variant="outline"
-                className="border-1 w-[72px] border border-gray-700 text-gray-700"
-                onClick={() => window.history.back()}>
-                취소
-              </Button>
-              <Button
-                variant="default"
                 className="w-[72px]"
                 onClick={handleSubmit}
-                disabled={updateProfileMutation.isPending}>
-                {updateProfileMutation.isPending ? <PageSpinner /> : '저장'}
+                disabled={updateProfileMutation.isPending}
+                pending={updateProfileMutation.isPending}>
+                저장
               </Button>
             </div>
           </div>

--- a/src/components/common/button/MoveBackButton.tsx
+++ b/src/components/common/button/MoveBackButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+
+interface MoveBackButtonProps {
+  text?: string;
+  className?: string;
+}
+
+// useRouter를 활용한 뒤로가기 버튼 (마이페이지 수정, 프로젝트 수정 등에서 재사용)
+export default function MoveBackButton({ text = '취소', className }: MoveBackButtonProps) {
+  const router = useRouter();
+
+  return (
+    <Button variant="outline" onClick={() => router.back()} className={className}>
+      {text}
+    </Button>
+  );
+}

--- a/src/components/common/modal/SelectTagModalLayout.tsx
+++ b/src/components/common/modal/SelectTagModalLayout.tsx
@@ -139,7 +139,7 @@ export default function SelectTagModalLayout({
         </div>
         <Separator className="my-2" />
         <div className="flex h-[25%] flex-col">
-          <div className="text-gray-700 display5">내가 선택한 역할</div>
+          <div className="text-gray-700 display5">내가 선택한 태그</div>
           <div
             ref={selectTagScrollRef}
             className="flex h-[45px] w-full items-center gap-1 overflow-x-auto scroll-smooth scrollbar-thin">

--- a/src/components/domain/project/projectRegisterModal/step/Step3.tsx
+++ b/src/components/domain/project/projectRegisterModal/step/Step3.tsx
@@ -45,7 +45,7 @@ export default function Step3() {
   const handleOpenSkillsModal = () => {
     openModal(
       <SelectTagModalLayout
-        title="역할 검색"
+        title="기술 스택 검색"
         colorTheme="gray"
         placeholder="프로젝트에 사용된 기술스택을 선택해 주세요."
         tagList={TechStacks}

--- a/src/components/domain/user/userProfile/UserProfile.tsx
+++ b/src/components/domain/user/userProfile/UserProfile.tsx
@@ -25,7 +25,7 @@ export default function UserProfile() {
     <section className="flex w-full">
       <div className="mr-4 flex w-[248px] flex-col items-center justify-center rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6">
         <CirclePlanetIcon className="bg-white" />
-        <span className="mt-2.5 text-white">안유경</span>
+        <span className="mt-2.5 text-white">{userData?.name}</span>
       </div>
       <BorderCard className="flex w-full min-w-0 max-w-[776px] flex-grow overflow-hidden p-8">
         <div className="grid grid-cols-[100px_1fr] gap-x-4 gap-y-2">

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -6,7 +6,7 @@ import { useModalStore } from '@/stores/modalStore';
 import type { LoginForm } from '@/models/auth/authModels';
 import { login, logout } from '../../services/api/authApi';
 import { useUserStore } from '@/stores/userStore';
-import { userData } from '@/services/api/userApi';
+import { userDataByLoginUser } from '@/services/api/userApi';
 
 export const useLogin = () => {
   const { closeModal } = useModalStore();
@@ -23,7 +23,7 @@ export const useLogin = () => {
 
       try {
         // 로그인 후 유저 데이터 가져오기
-        const userDataResponse = await userData();
+        const userDataResponse = await userDataByLoginUser();
         const data = userDataResponse.data;
 
         // 유저 데이터를 Zustand 스토어에 저장

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -28,6 +28,7 @@ export const useLogin = () => {
 
         // 유저 데이터를 Zustand 스토어에 저장
         setUser({
+          userId: data.userId,
           name: data.username,
           email: data.email,
           roles: data.interestJobs,

--- a/src/hooks/queries/useUserService.ts
+++ b/src/hooks/queries/useUserService.ts
@@ -1,35 +1,46 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { updateProfile, userData, getUserProfile } from '@/services/api/userApi';
+import { userProfileDataByUserId, updateProfile } from '@/services/api/userApi';
 import {
   UpdateProfileRequest,
   UpdateProfileResponse,
-  UserDataResponse,
   UserProfileResponse,
 } from '@/models/user/userApiModels';
 import { AxiosError } from 'axios';
+import { User } from '@/models/user/userModels';
+import { useUserStore } from '@/stores/userStore';
+import { useRouter } from 'next/navigation';
 
-export const useUserData = () => {
-  return useQuery<UserDataResponse, AxiosError>({
-    queryKey: ['userData'],
-    queryFn: userData,
-    retry: false,
-  });
-};
-
-// TODO: 로그인한 사용자 정보 받아올 때 userId zustand에 저장
-export const useUserProfile = (userId: string) => {
+// userId로 특정 사용자의 Profile Data 가져오기
+export const useUserProfileByUserId = (userId: string) => {
   return useQuery<UserProfileResponse, AxiosError>({
-    queryKey: ['userProfile', userId],
-    queryFn: () => getUserProfile(userId),
+    queryKey: ['userProfileByUserId', userId],
+    queryFn: () => userProfileDataByUserId(userId),
     retry: false,
   });
 };
 
+// 로그인 한 사용자의 프로필 수정하기
 export const useUpdateProfile = () => {
+  const router = useRouter();
+  const { user, setUser } = useUserStore();
+
   return useMutation<UpdateProfileResponse, AxiosError, UpdateProfileRequest>({
     mutationFn: updateProfile,
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       alert('프로필이 성공적으로 수정되었습니다.');
+
+      // 저장 성공 시, zustand의 전역 상태 업데이트 해주기
+      const userNewData: User = {
+        userId: user?.userId || '',
+        email: user?.email || '',
+        name: variables?.username || '',
+        roles: variables?.interestJobs || [],
+        skills: variables?.skills || [],
+      };
+      setUser(userNewData);
+
+      // 마이 페이지로 이동
+      router.push('/mypage');
     },
     onError: (error) => {
       console.error('프로필 수정 실패:', error);

--- a/src/models/user/userApiModels.ts
+++ b/src/models/user/userApiModels.ts
@@ -7,7 +7,6 @@ export interface UserDataResponse {
     username: string;
     interestJobs: string[];
     skills: string[];
-    introduction?: string;
   };
 }
 

--- a/src/models/user/userModels.ts
+++ b/src/models/user/userModels.ts
@@ -1,4 +1,6 @@
+// 로그인 한 유저의 데이터
 export interface User {
+  userId: string; // 유저 식별자
   name: string;
   email: string;
   roles: string[]; // 관심 직무

--- a/src/services/api/userApi.ts
+++ b/src/services/api/userApi.ts
@@ -7,7 +7,8 @@ import {
   UserProfileResponse,
 } from '@/models/user/userApiModels';
 
-export const userData = async (): Promise<UserDataResponse> => {
+// 로그인 한 사용자의 기본 데이터 가져오기 (로그인 시 호출)
+export const userDataByLoginUser = async (): Promise<UserDataResponse> => {
   try {
     const response = await ax.get<UserDataResponse>('/api/v1/users/me');
     return response.data;
@@ -27,7 +28,8 @@ export const userData = async (): Promise<UserDataResponse> => {
   }
 };
 
-export const getUserProfile = async (userId: string): Promise<UserProfileResponse> => {
+// 특정 사용자의 프로필 데이터 가져오기
+export const userProfileDataByUserId = async (userId: string): Promise<UserProfileResponse> => {
   try {
     const response = await ax.get<UserProfileResponse>(`/api/v1/users/${userId}/profile`);
     return response.data;


### PR DESCRIPTION
## 💡 ISSUE 번호

#74 

<br/>

## 🔎 작업 내용

- 로그인 시 돌려받은 userId도 전역 상태에 저장
- Logout 실행 시 PageSpinner 추가
- 함수 네이밍 변경
  - useUserData ->  useUserProfileByUserId
  - userData -> userDataByLoginUser
- MoveBackButton 컴포넌트 추가 (router 사용하여 뒤로가기 버튼 구현, 재사용 될 것 같아 생성. nextjs에서는 useRouter 을 사용해서 뒤로가기를 구현하는게 더 권장된다고 하네요)
- 유저 정보 수정 성공 시 userStore의 전역 상태 업데이트하고 마이페이지로 이동하게 기능 추가


<br/>

## 📢 주의 및 리뷰 요청

- 아까 슬랙으로 말씀 나눴던 부분 수정했습니다! 한번 확인 부탁드립니다


<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
