### PR TITLE
Feat/#56 프로젝트 상세 조회, 홈, 검색결과 페이지 스크린 제작 FEAT

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,10 @@ export default function Home() {
   return (
     <div className="container mx-auto min-h-screen p-12 flex-col-center">
       <div className="container flex w-[90%] justify-end">
-        <ProjectRegisterButton className="mb-20" />
+        <ProjectRegisterButton className="mb-20 h-12 w-60" />
       </div>
       <div className="w-full flex-center">
-        <ProjectSearchBar className="w-full max-w-[690px]" />
+        <ProjectSearchBar />
       </div>
     </div>
   );

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -1,18 +1,17 @@
-// 프로젝트 상세 조회 페이지
-// 내꺼인지 아닌지는 userId로 판단
+// 검색 결과에서 넘어온 프로젝트 상세 조회 페이지
 
-interface ProjectDetailPageProps {
+interface SearchProjectDetailPageProps {
   params: { projectId: string };
 }
 
-export default function ProjectDetailPage({ params }: ProjectDetailPageProps) {
+export default function SearchProjectDetailPage({ params }: SearchProjectDetailPageProps) {
   const projectId = params.projectId;
-
-  // Fetch 사용하여 데이터 가져오기
 
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
-      <div className="w-full bg-gray-800">프로젝트 상세 조회, Project ID: {projectId}</div>
+      <div className="w-full bg-gray-800">
+        프로젝트 검색 결과에서 넘어온 상세 조회, Project ID: {projectId}
+      </div>
     </div>
   );
 }

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -1,4 +1,13 @@
+'use client';
 // 검색 결과에서 넘어온 프로젝트 상세 조회 페이지
+// 이것도 페이지 전체가 서버에서 받아온 데이터가 필요해서.. nextjs의 fetch를 사용하는게 아니라면 .. ssr이 의미가 없을 것 같습니다..
+// use client 선언해서 사용하는게 좋을 것 같아요
+
+import BorderCard from '@/components/common/card/BorderCard';
+import TagInput from '@/components/common/input/TagInput';
+import UserSummaryCard from '@/components/domain/user/UserSummaryCard';
+import { USER_CARD_VARIANT } from '@/models/user/userModels';
+import { ArrowUpRight, CheckCircle2 } from 'lucide-react';
 
 interface SearchProjectDetailPageProps {
   params: { projectId: string };
@@ -6,11 +15,88 @@ interface SearchProjectDetailPageProps {
 
 export default function SearchProjectDetailPage({ params }: SearchProjectDetailPageProps) {
   const projectId = params.projectId;
-
+  console.log(projectId);
+  const testUserData = {
+    userId: '23fasdf',
+    name: '김프리즘',
+    email: 'rkfhadlwhgdk@naver.com',
+    roles: ['기획자', '디자이너'],
+  };
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
-      <div className="w-full bg-gray-800">
-        프로젝트 검색 결과에서 넘어온 상세 조회, Project ID: {projectId}
+      <div className="flex w-full max-w-[1040px] flex-col gap-10">
+        <section className="flex flex-col gap-4">
+          <h2 className="text-gray-900 body6">프로젝트 정보</h2>
+          <BorderCard className="flex flex-col justify-center gap-7 p-7">
+            <h3 className="flex flex-col gap-1">
+              <div className="text-gray-500 caption">
+                <span className="text-purple-500 mobile2">적극성</span>이 높은 팀원이 많은 팀의
+                프로젝트에요!
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-gray-700 body7">스위그 5기 6팀 팀프로젝트 PRism</span>
+                <span className="gap-1 text-gray-500 caption flex-center">
+                  <CheckCircle2 className="h-4 w-4 fill-success-50 stroke-success-500" />
+                  인증완료!
+                </span>
+              </div>
+            </h3>
+            <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
+              <div className="text-purple-800 display6">링크 바로가기</div>
+              <div className="flex items-center">
+                <a href="PRism.co.kr" className="text-gray-500 underline underline-offset-4">
+                  PRism.co.kr
+                </a>
+                <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
+              </div>
+              <div className="text-gray-600 display6">기관명</div>
+              <div className="text-black display4">스위그</div>
+              <div className="text-gray-600 display6">기간</div>
+              <div className="text-black display4">2024.05.11 - 2024.07.22</div>
+            </div>
+          </BorderCard>
+        </section>
+        <section className="flex flex-col gap-4">
+          <h2 className="text-gray-900 body6">프로젝트 산출물 정보</h2>
+          <BorderCard className="p-7">
+            <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
+              <div className="text-gray-600 display6">상세설명</div>
+              <div className="text-black display4">
+                이 프로젝트는 웰훕스팅 커뮤니티 이 프로젝트는 웰훕스팅 커뮤니티 스위코에서 주최한
+                6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를
+                마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은
+                프로젝트를 등록하고 평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는
+                것입니다.스위코에서 주최한 6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다.
+                PRism은 it프로젝트를 마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다.
+                주요 기능은 프로젝트를 등록하고 평가지를 보내 팀원들의 평가를 받아 5가지의 지표로
+                나타내는 것입니다.
+              </div>
+
+              <div className="text-gray-600 display6">카테고리</div>
+              <div className="flex gap-2">
+                <TagInput value="금융" isDisabled />
+                <TagInput value="생산성" isDisabled />
+                <TagInput value="기타" isDisabled />
+              </div>
+
+              <div className="text-gray-600 display6">기술스택</div>
+              <div className="flex gap-2">
+                <TagInput value="Spring Framework" isDisabled colorTheme="gray" />
+                <TagInput value="Python" isDisabled colorTheme="gray" />
+                <TagInput value="HTML/CSS" isDisabled colorTheme="gray" />
+              </div>
+            </div>
+          </BorderCard>
+        </section>
+        <section className="flex flex-col gap-4">
+          <h2 className="text-gray-900 body6">팀원 정보</h2>
+          <div className="flex flex-wrap gap-4">
+            <UserSummaryCard userData={testUserData} />
+            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.NON_MEMBER} />
+            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PRIVATE} />
+            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PUBLIC} />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -61,7 +61,7 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
           <BorderCard className="p-7">
             <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
               <div className="text-gray-600 display6">상세설명</div>
-              <div className="text-black display4">
+              <p className="text-black display4">
                 이 프로젝트는 웰훕스팅 커뮤니티 이 프로젝트는 웰훕스팅 커뮤니티 스위코에서 주최한
                 6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를
                 마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은
@@ -70,32 +70,55 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                 PRism은 it프로젝트를 마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다.
                 주요 기능은 프로젝트를 등록하고 평가지를 보내 팀원들의 평가를 받아 5가지의 지표로
                 나타내는 것입니다.
-              </div>
+              </p>
 
               <div className="text-gray-600 display6">카테고리</div>
-              <div className="flex gap-2">
-                <TagInput value="금융" isDisabled />
-                <TagInput value="생산성" isDisabled />
-                <TagInput value="기타" isDisabled />
-              </div>
+              <ul className="flex gap-2">
+                <li>
+                  {' '}
+                  <TagInput value="금융" isDisabled />
+                </li>
+                <li>
+                  {' '}
+                  <TagInput value="생산성" isDisabled />
+                </li>
+                <li>
+                  {' '}
+                  <TagInput value="기타" isDisabled />
+                </li>
+              </ul>
 
               <div className="text-gray-600 display6">기술스택</div>
-              <div className="flex gap-2">
-                <TagInput value="Spring Framework" isDisabled colorTheme="gray" />
-                <TagInput value="Python" isDisabled colorTheme="gray" />
-                <TagInput value="HTML/CSS" isDisabled colorTheme="gray" />
-              </div>
+              <ul className="flex gap-2">
+                <li>
+                  <TagInput value="Spring Framework" isDisabled colorTheme="gray" />
+                </li>
+                <li>
+                  <TagInput value="Python" isDisabled colorTheme="gray" />
+                </li>
+                <li>
+                  <TagInput value="HTML/CSS" isDisabled colorTheme="gray" />
+                </li>
+              </ul>
             </div>
           </BorderCard>
         </section>
         <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">팀원 정보</h2>
-          <div className="flex flex-wrap gap-4">
-            <UserSummaryCard userData={testUserData} />
-            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.NON_MEMBER} />
-            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PRIVATE} />
-            <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PUBLIC} />
-          </div>
+          <ul className="flex flex-wrap gap-4">
+            <li>
+              <UserSummaryCard userData={testUserData} />
+            </li>
+            <li>
+              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.NON_MEMBER} />
+            </li>
+            <li>
+              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PRIVATE} />
+            </li>
+            <li>
+              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PUBLIC} />
+            </li>
+          </ul>
         </section>
       </div>
     </div>

--- a/src/app/project/my/[projectId]/page.tsx
+++ b/src/app/project/my/[projectId]/page.tsx
@@ -1,6 +1,7 @@
 // 마이 프로필에서 넘어온 프로젝트 상세 조회 페이지
 
 import BorderCard from '@/components/common/card/BorderCard';
+import OverallPRismReport from '@/components/domain/prism/OverallPRismReport';
 import ProjectIntroduceCard from '@/components/domain/project/projectCard/ProjectIntroduceCard';
 
 interface MyProjectDetailPageProps {
@@ -12,15 +13,15 @@ export default function MyProjectDetailPage({ params }: MyProjectDetailPageProps
 
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
-      <div className="flex w-full max-w-[1040px] flex-col">
+      <div className="flex w-full max-w-[1040px] flex-col gap-10">
         {/* 마이프로필에서 넘어온 상세 조회, Project ID: {projectId} */}
         <ProjectIntroduceCard fromMyProfile projectId={projectId} />
         <section>
-          <h2>나의 PRism</h2>
-          <BorderCard>나의 PRism</BorderCard>
+          <h2 className="text-gray-900 body6">나의 PRism</h2>
+          <OverallPRismReport />
         </section>
         <section>
-          <h2>나의 PRism 분석 리포트</h2>
+          <h2 className="text-gray-900 body6">나의 PRism 분석 리포트</h2>
           <BorderCard>나의 PRism 분석 리포트</BorderCard>
         </section>
       </div>

--- a/src/app/project/my/[projectId]/page.tsx
+++ b/src/app/project/my/[projectId]/page.tsx
@@ -1,7 +1,6 @@
 // 마이 프로필에서 넘어온 프로젝트 상세 조회 페이지
-
-import BorderCard from '@/components/common/card/BorderCard';
-import OverallPRismReport from '@/components/domain/prism/OverallPRismReport';
+import PrismAnalyzeReport from '@/components/domain/prism/PrismAnalyzeReport';
+import PrismReport from '@/components/domain/prism/PRismReport';
 import ProjectIntroduceCard from '@/components/domain/project/projectCard/ProjectIntroduceCard';
 
 interface MyProjectDetailPageProps {
@@ -16,13 +15,13 @@ export default function MyProjectDetailPage({ params }: MyProjectDetailPageProps
       <div className="flex w-full max-w-[1040px] flex-col gap-10">
         {/* 마이프로필에서 넘어온 상세 조회, Project ID: {projectId} */}
         <ProjectIntroduceCard fromMyProfile projectId={projectId} />
-        <section>
+        <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">나의 PRism</h2>
-          <OverallPRismReport />
+          <PrismReport />
         </section>
-        <section>
+        <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">나의 PRism 분석 리포트</h2>
-          <BorderCard>나의 PRism 분석 리포트</BorderCard>
+          <PrismAnalyzeReport />
         </section>
       </div>
     </div>

--- a/src/app/project/my/[projectId]/page.tsx
+++ b/src/app/project/my/[projectId]/page.tsx
@@ -1,0 +1,29 @@
+// 마이 프로필에서 넘어온 프로젝트 상세 조회 페이지
+
+import BorderCard from '@/components/common/card/BorderCard';
+import ProjectIntroduceCard from '@/components/domain/project/projectCard/ProjectIntroduceCard';
+
+interface MyProjectDetailPageProps {
+  params: { projectId: string };
+}
+
+export default function MyProjectDetailPage({ params }: MyProjectDetailPageProps) {
+  const projectId = Number(params.projectId);
+
+  return (
+    <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
+      <div className="flex w-full max-w-[1040px] flex-col">
+        {/* 마이프로필에서 넘어온 상세 조회, Project ID: {projectId} */}
+        <ProjectIntroduceCard fromMyProfile projectId={projectId} />
+        <section>
+          <h2>나의 PRism</h2>
+          <BorderCard>나의 PRism</BorderCard>
+        </section>
+        <section>
+          <h2>나의 PRism 분석 리포트</h2>
+          <BorderCard>나의 PRism 분석 리포트</BorderCard>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/project/user/[userId]/[projectId]/page.tsx
+++ b/src/app/project/user/[userId]/[projectId]/page.tsx
@@ -1,0 +1,20 @@
+// 타인 프로필에서 넘어온 프로젝트 상세 조회 페이지
+
+interface UserProjectDetailPageProps {
+  params: {
+    userId: string;
+    projectId: string;
+  };
+}
+
+export default function UserProjectDetailPage({
+  params: { userId, projectId },
+}: UserProjectDetailPageProps) {
+  return (
+    <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
+      <div className="w-full bg-pink-400">
+        타인 프로필에서 넘어온 상세 조회, UserId: {userId} / Project ID: {projectId}
+      </div>
+    </div>
+  );
+}

--- a/src/app/project/user/[userId]/[projectId]/page.tsx
+++ b/src/app/project/user/[userId]/[projectId]/page.tsx
@@ -1,19 +1,29 @@
-// 타인 프로필에서 넘어온 프로젝트 상세 조회 페이지
+// 다른 유저 프로필에서 넘어온 프로젝트 상세 조회 페이지
+import PrismAnalyzeReport from '@/components/domain/prism/PrismAnalyzeReport';
+import PrismReport from '@/components/domain/prism/PRismReport';
+import ProjectIntroduceCard from '@/components/domain/project/projectCard/ProjectIntroduceCard';
 
 interface UserProjectDetailPageProps {
-  params: {
-    userId: string;
-    projectId: string;
-  };
+  params: { userId: string; projectId: string };
 }
 
-export default function UserProjectDetailPage({
-  params: { userId, projectId },
-}: UserProjectDetailPageProps) {
+export default function UserProjectDetailPage({ params }: UserProjectDetailPageProps) {
+  const userId = params.userId;
+  const projectId = Number(params.projectId);
+
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
-      <div className="w-full bg-pink-400">
-        타인 프로필에서 넘어온 상세 조회, UserId: {userId} / Project ID: {projectId}
+      <div className="flex w-full max-w-[1040px] flex-col gap-10">
+        {/* 유저 프로필에서 넘어온 상세 조회, Project ID: {projectId} */}
+        <ProjectIntroduceCard userId={userId} projectId={projectId} />
+        <section className="flex flex-col gap-4">
+          <h2 className="text-gray-900 body6">나의 PRism</h2>
+          <PrismReport />
+        </section>
+        <section className="flex flex-col gap-4">
+          <h2 className="text-gray-900 body6">나의 PRism 분석 리포트</h2>
+          <PrismAnalyzeReport />
+        </section>
       </div>
     </div>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+// 퍼블리싱만 먼저 빠르게 함. 'use client'; 지우고 컴포넌트 분리할지 고민 필요
+
+import { useState } from 'react';
+import ProjectSummaryCard from '@/components/domain/project/projectCard/ProjectSummaryCard';
+import ProjectSearchBar from '@/components/domain/project/projectSearch/ProjectSearchBar';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import { convertStringToDate } from '@/lib/dateTime';
+
+export default function SearchPage() {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalItems = 30; // 총 프로젝트가 30개라고 가정
+  const itemsPerPage = 8; // 한 페이지에 8개씩 보여줌
+  const totalPages = Math.ceil(totalItems / itemsPerPage); // 4
+
+  const handleClickPaginationItem = (page: number) => {
+    setCurrentPage(page);
+  };
+  const testData = [
+    {
+      projectId: 1,
+      projectname: 'project.projectName1',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 2,
+      projectname: 'project.proj4ectName2',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 3,
+      projectname: 'project.project1Name',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 5,
+      projectname: 'project.projectName3',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 6,
+      projectname: 'project.projectName3',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 7,
+      projectname: 'project.projectName3',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+    {
+      projectId: 8,
+      projectname: 'project.projectName3',
+      startDate: convertStringToDate('2024-02-02'),
+      endDate: convertStringToDate('2024-05-02'),
+      organizationName: 'project.organizationName',
+      categories: ['기타', '금융', '생산성'],
+      evaluatedMembersCount: 0,
+    },
+  ];
+  return (
+    <>
+      <div className="absolute h-56 w-full bg-white flex-center">
+        <section className="w-full max-w-[1500px] flex-center">
+          <ProjectSearchBar defaultDetailVisible />
+        </section>
+      </div>
+      <div className="container mx-auto mb-14 flex min-h-screen flex-col items-center gap-16 pt-60">
+        <section className="flex w-full max-w-[1040px] flex-col gap-5">
+          <h2 className="text-gray-900 body6">프로젝트 목록</h2>
+          <ul className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
+            {testData.map((projectData) => (
+              <li key={projectData.projectId} className="w-full">
+                <ProjectSummaryCard projectData={projectData} />
+              </li>
+            ))}
+          </ul>
+        </section>
+        <nav>
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious />
+              </PaginationItem>
+              {[...Array(totalPages)].map((_, index) => (
+                <PaginationItem key={index} onClick={() => handleClickPaginationItem(index + 1)}>
+                  <PaginationLink isActive={currentPage === index + 1}>{index + 1}</PaginationLink>
+                </PaginationItem>
+              ))}
+              {/* 필요 시 PaginationEllipsis 사용 */}
+              {/* <PaginationItem>
+                <PaginationEllipsis />
+              </PaginationItem> */}
+              <PaginationItem>
+                <PaginationNext />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </nav>
+      </div>
+    </>
+  );
+}

--- a/src/components/common/chart/PRismChart.tsx
+++ b/src/components/common/chart/PRismChart.tsx
@@ -5,20 +5,12 @@ import { Flag, Puzzle, Users, Wand2, Wrench } from 'lucide-react';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
-import { PRISM_EVALUATIONS, type PRismEvaluationType } from '@/models/evaluation/evaluationModels';
-
-const EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
-  COMMUNICATION: '의사소통능력',
-  PROACTIVITY: '적극성',
-  PROBLEM_SOLVING: '문제해결능력',
-  RESPONSIBILITY: '책임감',
-  COOPERATION: '협동심',
-};
-
-export interface Evaluation {
-  evaluation: PRismEvaluationType;
-  percent: number;
-}
+import {
+  EVALUATION_LABELS,
+  PRISM_EVALUATIONS,
+  type Evaluation,
+  type PRismEvaluationType,
+} from '@/models/prism/prismModels';
 
 interface PRismChartComponentProps {
   data: Evaluation[];
@@ -89,7 +81,7 @@ interface CustomAxisTickProps {
   fontSize?: number;
 }
 
-const ICONS: Record<PRismEvaluationType, React.ElementType> = {
+export const ICONS: Record<PRismEvaluationType, React.ElementType> = {
   COMMUNICATION: Users,
   PROACTIVITY: Wand2,
   PROBLEM_SOLVING: Wrench,
@@ -126,3 +118,27 @@ const CustomAxisTick = ({ x, y, payload, fontSize = 14 }: CustomAxisTickProps) =
     </g>
   );
 };
+
+// 데이터 로딩 전 임시 데이터
+export const defaultPRismChartData: Evaluation[] = [
+  {
+    evaluation: 'COMMUNICATION',
+    percent: 30,
+  },
+  {
+    evaluation: 'PROACTIVITY',
+    percent: 40,
+  },
+  {
+    evaluation: 'PROBLEM_SOLVING',
+    percent: 100,
+  },
+  {
+    evaluation: 'RESPONSIBILITY',
+    percent: 80,
+  },
+  {
+    evaluation: 'COOPERATION',
+    percent: 90,
+  },
+];

--- a/src/components/common/chart/PRismChart.tsx
+++ b/src/components/common/chart/PRismChart.tsx
@@ -6,14 +6,14 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
 import {
-  EVALUATION_LABELS,
+  PRISM_EVALUATION_LABELS,
   PRISM_EVALUATIONS,
-  type Evaluation,
+  type PRismEvaluation,
   type PRismEvaluationType,
 } from '@/models/prism/prismModels';
 
 interface PRismChartComponentProps {
-  data: Evaluation[];
+  data: PRismEvaluation[];
   name?: string; // 지표에 표시될 사용자 이름
   hideAxis?: boolean;
   fontSize?: number;
@@ -110,7 +110,7 @@ const CustomAxisTick = ({ x, y, payload, fontSize = 14 }: CustomAxisTickProps) =
         textAnchor="middle"
         className="m-4 fill-gray-400"
         fontSize={fontSize}>
-        {EVALUATION_LABELS[payload.value]}
+        {PRISM_EVALUATION_LABELS[payload.value]}
       </text>
       <foreignObject x={-10} y={-20} width={30} height={30}>
         <Icon className="h-5 w-5" />
@@ -120,7 +120,7 @@ const CustomAxisTick = ({ x, y, payload, fontSize = 14 }: CustomAxisTickProps) =
 };
 
 // 데이터 로딩 전 임시 데이터
-export const defaultPRismChartData: Evaluation[] = [
+export const defaultPRismChartData: PRismEvaluation[] = [
   {
     evaluation: 'COMMUNICATION',
     percent: 30,

--- a/src/components/common/chart/RadialChart.tsx
+++ b/src/components/common/chart/RadialChart.tsx
@@ -4,10 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Crown, HeartHandshake, Cog } from 'lucide-react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
-import {
-  RADIAL_EVALUATION_TYPES,
-  type RadialEvaluationType,
-} from '@/models/evaluation/evaluationModels';
+import { RADIAL_EVALUATION_TYPES, type RadialEvaluationType } from '@/models/prism/prismModels';
 
 export const EVALUATION_INFO: Record<
   RadialEvaluationType,

--- a/src/components/common/chart/RadialChart.tsx
+++ b/src/components/common/chart/RadialChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Crown, HeartHandshake, Gem } from 'lucide-react';
+import { Crown, HeartHandshake, Cog } from 'lucide-react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
 import {
@@ -27,9 +27,9 @@ export const EVALUATION_INFO: Record<
     icon: HeartHandshake,
     color: tailwindColors.purple[800],
   },
-  [RADIAL_EVALUATION_TYPES.CHARISMA]: {
-    label: '매력도',
-    icon: Gem,
+  [RADIAL_EVALUATION_TYPES.TEAMWORK]: {
+    label: '팀워크',
+    icon: Cog,
     color: tailwindColors.purple[900],
   },
 };

--- a/src/components/common/chart/RadialChart.tsx
+++ b/src/components/common/chart/RadialChart.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Crown, HeartHandshake, Cog } from 'lucide-react';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
 import tailwindColors from 'tailwindcss/colors';
-import { RADIAL_EVALUATION_TYPES, type RadialEvaluationType } from '@/models/prism/prismModels';
+import { RADIAL_EVALUATION_LABELS, type RadialEvaluationType } from '@/models/prism/prismModels';
 
 export const EVALUATION_INFO: Record<
   RadialEvaluationType,
@@ -14,18 +14,18 @@ export const EVALUATION_INFO: Record<
     color: string;
   }
 > = {
-  [RADIAL_EVALUATION_TYPES.LEADERSHIP]: {
-    label: '리더십',
+  LEADERSHIP: {
+    label: RADIAL_EVALUATION_LABELS.LEADERSHIP,
     icon: Crown,
     color: tailwindColors.purple[900],
   },
-  [RADIAL_EVALUATION_TYPES.RELIABILITY]: {
-    label: '신뢰도',
+  RELIABILITY: {
+    label: RADIAL_EVALUATION_LABELS.RELIABILITY,
     icon: HeartHandshake,
     color: tailwindColors.purple[800],
   },
-  [RADIAL_EVALUATION_TYPES.TEAMWORK]: {
-    label: '팀워크',
+  TEAMWORK: {
+    label: RADIAL_EVALUATION_LABELS.TEAMWORK,
     icon: Cog,
     color: tailwindColors.purple[900],
   },

--- a/src/components/domain/prism/OverallPRismReport.tsx
+++ b/src/components/domain/prism/OverallPRismReport.tsx
@@ -67,13 +67,13 @@ export default function OverallPRismReport() {
           <PRismChart data={chartData} />
         </div>
       </div>
-      <div className="flex h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
+      <div className="flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
         <div className="text-indigo-800 body6">나의 PRism 분석 리포트</div>
         <div className="gap-3 flex-col-center">
-          <div className="flex-center">
+          <div className="flex-wrap flex-center">
             <RadialChart type={RADIAL_EVALUATION_TYPES.LEADERSHIP} value={70} />
             <RadialChart type={RADIAL_EVALUATION_TYPES.RELIABILITY} value={80} />
-            <RadialChart type={RADIAL_EVALUATION_TYPES.CHARISMA} value={50} />
+            <RadialChart type={RADIAL_EVALUATION_TYPES.TEAMWORK} value={50} />
           </div>
           <div className="grid grid-cols-[80px_1fr] gap-x-2 gap-y-2">
             {prismTextData.map((item, index) => (

--- a/src/components/domain/prism/OverallPRismReport.tsx
+++ b/src/components/domain/prism/OverallPRismReport.tsx
@@ -2,20 +2,18 @@
 
 import { useState, useEffect } from 'react';
 import BorderCard from '@/components/common/card/BorderCard';
-import PRismChart, {
-  defaultPRismChartData,
-  Evaluation,
-} from '@/components/common/chart/PRismChart';
+import PRismChart, { defaultPRismChartData } from '@/components/common/chart/PRismChart';
 import TripleRadialChart, {
   defaultTripleRadialChartData,
-  type RadilChartData,
+  type RadialChartData,
 } from './report/TripleRadialChart';
 import ReportBlur from './report/ReportBlur';
+import type { PRismEvaluation } from '@/models/prism/prismModels';
 
 export default function OverallPRismReport() {
   const [hasData, setHasData] = useState<boolean>(false);
-  const [chartData] = useState<Evaluation[]>(defaultPRismChartData);
-  const [radialChartData] = useState<RadilChartData>(defaultTripleRadialChartData);
+  const [chartData] = useState<PRismEvaluation[]>(defaultPRismChartData);
+  const [radialChartData] = useState<RadialChartData>(defaultTripleRadialChartData);
 
   // TODO: API 연동 후 데이터를 받아와서 setHasData(true) 호출, 나중에 isPending으로 변경
   useEffect(() => {

--- a/src/components/domain/prism/PRismReport.tsx
+++ b/src/components/domain/prism/PRismReport.tsx
@@ -1,21 +1,16 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import BorderCard from '@/components/common/card/BorderCard';
-import PRismChart, {
-  defaultPRismChartData,
-  Evaluation,
-} from '@/components/common/chart/PRismChart';
-import TripleRadialChart, {
-  defaultTripleRadialChartData,
-  type RadilChartData,
-} from './report/TripleRadialChart';
-import ReportBlur from './report/ReportBlur';
 
-export default function OverallPRismReport() {
+import BorderCard from '@/components/common/card/BorderCard';
+import ReportBlur from './report/ReportBlur';
+import PRismChart, { defaultPRismChartData } from '@/components/common/chart/PRismChart';
+import PRismExplanation from './report/PRismExplanation';
+import type { Evaluation } from '@/models/prism/prismModels';
+
+export default function PrismReport() {
   const [hasData, setHasData] = useState<boolean>(false);
   const [chartData] = useState<Evaluation[]>(defaultPRismChartData);
-  const [radialChartData] = useState<RadilChartData>(defaultTripleRadialChartData);
 
   // TODO: API 연동 후 데이터를 받아와서 setHasData(true) 호출, 나중에 isPending으로 변경
   useEffect(() => {
@@ -27,17 +22,15 @@ export default function OverallPRismReport() {
   }, []);
 
   return (
-    <BorderCard className="relative flex-wrap gap-8 flex-center">
+    <BorderCard className="relative flex-wrap gap-28 flex-center">
       {!hasData && <ReportBlur />}
       <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism</div>
         <div className="h-full w-full">
           <PRismChart data={chartData} />
         </div>
       </div>
-      <div className="flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism 분석 리포트</div>
-        <TripleRadialChart data={radialChartData} />
+      <div className="rounded-[30px]px-9 flex min-h-[330px] max-w-[560px] gap-3 py-3 flex-col-center">
+        <PRismExplanation userName="김이름" data={chartData} />
       </div>
     </BorderCard>
   );

--- a/src/components/domain/prism/PRismReport.tsx
+++ b/src/components/domain/prism/PRismReport.tsx
@@ -6,11 +6,11 @@ import BorderCard from '@/components/common/card/BorderCard';
 import ReportBlur from './report/ReportBlur';
 import PRismChart, { defaultPRismChartData } from '@/components/common/chart/PRismChart';
 import PRismExplanation from './report/PRismExplanation';
-import type { Evaluation } from '@/models/prism/prismModels';
+import type { PRismEvaluation } from '@/models/prism/prismModels';
 
 export default function PrismReport() {
   const [hasData, setHasData] = useState<boolean>(false);
-  const [chartData] = useState<Evaluation[]>(defaultPRismChartData);
+  const [chartData] = useState<PRismEvaluation[]>(defaultPRismChartData);
 
   // TODO: API 연동 후 데이터를 받아와서 setHasData(true) 호출, 나중에 isPending으로 변경
   useEffect(() => {

--- a/src/components/domain/prism/PrismAnalyzeReport.tsx
+++ b/src/components/domain/prism/PrismAnalyzeReport.tsx
@@ -1,20 +1,15 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+
 import BorderCard from '@/components/common/card/BorderCard';
-import PRismChart, {
-  defaultPRismChartData,
-  Evaluation,
-} from '@/components/common/chart/PRismChart';
 import TripleRadialChart, {
   defaultTripleRadialChartData,
   type RadilChartData,
 } from './report/TripleRadialChart';
 import ReportBlur from './report/ReportBlur';
-
-export default function OverallPRismReport() {
+export default function PrismAnalyzeReport() {
   const [hasData, setHasData] = useState<boolean>(false);
-  const [chartData] = useState<Evaluation[]>(defaultPRismChartData);
   const [radialChartData] = useState<RadilChartData>(defaultTripleRadialChartData);
 
   // TODO: API 연동 후 데이터를 받아와서 setHasData(true) 호출, 나중에 isPending으로 변경
@@ -27,18 +22,9 @@ export default function OverallPRismReport() {
   }, []);
 
   return (
-    <BorderCard className="relative flex-wrap gap-8 flex-center">
+    <BorderCard className="relative flex-wrap flex-center">
       {!hasData && <ReportBlur />}
-      <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism</div>
-        <div className="h-full w-full">
-          <PRismChart data={chartData} />
-        </div>
-      </div>
-      <div className="flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism 분석 리포트</div>
-        <TripleRadialChart data={radialChartData} />
-      </div>
+      <TripleRadialChart data={radialChartData} radialParentClassName="gap-10" />
     </BorderCard>
   );
 }

--- a/src/components/domain/prism/PrismAnalyzeReport.tsx
+++ b/src/components/domain/prism/PrismAnalyzeReport.tsx
@@ -5,12 +5,12 @@ import { useState, useEffect } from 'react';
 import BorderCard from '@/components/common/card/BorderCard';
 import TripleRadialChart, {
   defaultTripleRadialChartData,
-  type RadilChartData,
+  type RadialChartData,
 } from './report/TripleRadialChart';
 import ReportBlur from './report/ReportBlur';
 export default function PrismAnalyzeReport() {
   const [hasData, setHasData] = useState<boolean>(false);
-  const [radialChartData] = useState<RadilChartData>(defaultTripleRadialChartData);
+  const [radialChartData] = useState<RadialChartData>(defaultTripleRadialChartData);
 
   // TODO: API 연동 후 데이터를 받아와서 setHasData(true) 호출, 나중에 isPending으로 변경
   useEffect(() => {

--- a/src/components/domain/prism/report/PRismExplanation.tsx
+++ b/src/components/domain/prism/report/PRismExplanation.tsx
@@ -1,0 +1,83 @@
+import {
+  EVALUATION_LABELS,
+  type Evaluation,
+  type PRismEvaluationType,
+} from '@/models/prism/prismModels';
+import { ICONS } from '@/components/common/chart/PRismChart';
+
+interface PRismExplanationProps {
+  userName: string;
+  data: Evaluation[];
+}
+
+export default function PRismExplanation({ userName, data }: PRismExplanationProps) {
+  const { highestEvaluations, lowestEvaluations } = findExtremeEvaluations(data);
+
+  const getColorForEvaluation = (evaluation: PRismEvaluationType) => {
+    if (highestEvaluations.includes(evaluation)) return 'text-info-500';
+    if (lowestEvaluations.includes(evaluation)) return 'text-purple-500';
+    return 'text-gray-500'; // 기본 색상
+  };
+
+  return (
+    <div className="flex-wrap gap-12 flex-col-center">
+      <div className="flex-wrap gap-10 flex-center">
+        {data.map((item) => {
+          const Icon = ICONS[item.evaluation];
+          return (
+            <span key={item.evaluation} className="gap-2 flex-col-center">
+              <div className="gap-1 text-gray-400 mobile2 flex-col-center">
+                <Icon className="stroke-black" />
+                {EVALUATION_LABELS[item.evaluation]}
+              </div>
+              <span className={`mobile1 ${getColorForEvaluation(item.evaluation)}`}>
+                {item.percent}%
+              </span>
+            </span>
+          );
+        })}
+      </div>
+      <div className="flex flex-col justify-center gap-4 text-gray-800 display5">
+        <p>
+          {userName}님의 <span className="text-info-500 mobile2">가장 높은 지표</span>는
+          <span className="mx-2 text-info-500 display6">
+            {highestEvaluations.map((evaluation) => EVALUATION_LABELS[evaluation]).join(', ')}
+          </span>
+          입니다.
+        </p>
+        <p>
+          {userName}님의 <span className="text-purple-500 mobile2">가장 낮은 지표</span>는
+          <span className="mx-2 text-purple-500 display6">
+            {lowestEvaluations.map((evaluation) => EVALUATION_LABELS[evaluation]).join(', ')}
+          </span>
+          입니다.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const findExtremeEvaluations = (data: Evaluation[]) => {
+  let maxPercent = -Infinity;
+  let minPercent = Infinity;
+  let highestEvaluations: PRismEvaluationType[] = [];
+  let lowestEvaluations: PRismEvaluationType[] = [];
+
+  data.forEach((item) => {
+    if (item.percent > maxPercent) {
+      maxPercent = item.percent;
+      highestEvaluations = [item.evaluation];
+    } else if (item.percent === maxPercent) {
+      highestEvaluations.push(item.evaluation);
+    }
+
+    if (item.percent < minPercent) {
+      minPercent = item.percent;
+      lowestEvaluations = [item.evaluation];
+    } else if (item.percent === minPercent) {
+      lowestEvaluations.push(item.evaluation);
+    }
+  });
+
+  return { highestEvaluations, lowestEvaluations };
+};

--- a/src/components/domain/prism/report/PRismExplanation.tsx
+++ b/src/components/domain/prism/report/PRismExplanation.tsx
@@ -1,13 +1,13 @@
 import {
-  EVALUATION_LABELS,
-  type Evaluation,
+  PRISM_EVALUATION_LABELS,
+  type PRismEvaluation,
   type PRismEvaluationType,
 } from '@/models/prism/prismModels';
 import { ICONS } from '@/components/common/chart/PRismChart';
 
 interface PRismExplanationProps {
   userName: string;
-  data: Evaluation[];
+  data: PRismEvaluation[];
 }
 
 export default function PRismExplanation({ userName, data }: PRismExplanationProps) {
@@ -28,7 +28,7 @@ export default function PRismExplanation({ userName, data }: PRismExplanationPro
             <span key={item.evaluation} className="gap-2 flex-col-center">
               <div className="gap-1 text-gray-400 mobile2 flex-col-center">
                 <Icon className="stroke-black" />
-                {EVALUATION_LABELS[item.evaluation]}
+                {PRISM_EVALUATION_LABELS[item.evaluation]}
               </div>
               <span className={`mobile1 ${getColorForEvaluation(item.evaluation)}`}>
                 {item.percent}%
@@ -41,14 +41,14 @@ export default function PRismExplanation({ userName, data }: PRismExplanationPro
         <p>
           {userName}님의 <span className="text-info-500 mobile2">가장 높은 지표</span>는
           <span className="mx-2 text-info-500 display6">
-            {highestEvaluations.map((evaluation) => EVALUATION_LABELS[evaluation]).join(', ')}
+            {highestEvaluations.map((evaluation) => PRISM_EVALUATION_LABELS[evaluation]).join(', ')}
           </span>
           입니다.
         </p>
         <p>
           {userName}님의 <span className="text-purple-500 mobile2">가장 낮은 지표</span>는
           <span className="mx-2 text-purple-500 display6">
-            {lowestEvaluations.map((evaluation) => EVALUATION_LABELS[evaluation]).join(', ')}
+            {lowestEvaluations.map((evaluation) => PRISM_EVALUATION_LABELS[evaluation]).join(', ')}
           </span>
           입니다.
         </p>
@@ -57,7 +57,7 @@ export default function PRismExplanation({ userName, data }: PRismExplanationPro
   );
 }
 
-const findExtremeEvaluations = (data: Evaluation[]) => {
+const findExtremeEvaluations = (data: PRismEvaluation[]) => {
   let maxPercent = -Infinity;
   let minPercent = Infinity;
   let highestEvaluations: PRismEvaluationType[] = [];

--- a/src/components/domain/prism/report/ReportBlur.tsx
+++ b/src/components/domain/prism/report/ReportBlur.tsx
@@ -1,0 +1,8 @@
+export default function ReportBlur() {
+  return (
+    <div className="absolute inset-1 z-10 flex rounded-[30px] bg-white bg-opacity-70 backdrop-blur-sm flex-col-center">
+      <p className="text-gray-700 body6">아직 나의 PRism이 없어요!</p>
+      <p className="text-purple-800 display4">프로젝트를 등록하고 나만의 PRism을 시작해 보세요.</p>
+    </div>
+  );
+}

--- a/src/components/domain/prism/report/TripleRadialChart.tsx
+++ b/src/components/domain/prism/report/TripleRadialChart.tsx
@@ -3,16 +3,16 @@
 import RadialChart from '@/components/common/chart/RadialChart';
 import TagInput from '@/components/common/input/TagInput';
 import { cn } from '@/lib/utils';
-import { RADIAL_EVALUATION_TYPES, type RadialEvaluationType } from '@/models/prism/prismModels';
+import { RADIAL_EVALUATIONS, type RadialEvaluationType } from '@/models/prism/prismModels';
 
-export interface RadilChartData {
+export interface RadialChartData {
   radialChartData: Record<RadialEvaluationType, number>;
   keyword: string[];
   evaluation: string;
 }
 
 interface TripleRadialChartProps {
-  data: RadilChartData;
+  data: RadialChartData;
   radialParentClassName?: string;
 }
 
@@ -24,8 +24,8 @@ export default function TripleRadialChart({ data, radialParentClassName }: Tripl
   return (
     <div className={cn('flex min-h-[330px] max-w-[560px] flex-col justify-center gap-5')}>
       <div className={cn('flex-wrap flex-center', radialParentClassName)}>
-        {Object.entries(data.radialChartData).map(([type, value]) => (
-          <RadialChart key={type} type={type as RadialEvaluationType} value={value} />
+        {RADIAL_EVALUATIONS.map((type) => (
+          <RadialChart key={type} type={type} value={data.radialChartData[type]} />
         ))}
       </div>
       <div className="grid grid-cols-[100px_1fr] gap-x-2 gap-y-2">
@@ -48,11 +48,11 @@ export default function TripleRadialChart({ data, radialParentClassName }: Tripl
   );
 }
 
-export const defaultTripleRadialChartData: RadilChartData = {
+export const defaultTripleRadialChartData: RadialChartData = {
   radialChartData: {
-    [RADIAL_EVALUATION_TYPES.LEADERSHIP]: 70,
-    [RADIAL_EVALUATION_TYPES.RELIABILITY]: 80,
-    [RADIAL_EVALUATION_TYPES.TEAMWORK]: 60,
+    LEADERSHIP: 70,
+    RELIABILITY: 80,
+    TEAMWORK: 60,
   },
   keyword: ['배려', '책임감', '도전정신'],
   evaluation:

--- a/src/components/domain/prism/report/TripleRadialChart.tsx
+++ b/src/components/domain/prism/report/TripleRadialChart.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import RadialChart from '@/components/common/chart/RadialChart';
+import TagInput from '@/components/common/input/TagInput';
+import { cn } from '@/lib/utils';
+import { RADIAL_EVALUATION_TYPES, type RadialEvaluationType } from '@/models/prism/prismModels';
+
+export interface RadilChartData {
+  radialChartData: Record<RadialEvaluationType, number>;
+  keyword: string[];
+  evaluation: string;
+}
+
+interface TripleRadialChartProps {
+  data: RadilChartData;
+  radialParentClassName?: string;
+}
+
+export default function TripleRadialChart({ data, radialParentClassName }: TripleRadialChartProps) {
+  const gridTextData = [
+    { id: 'keyword', label: '키워드', value: data.keyword },
+    { id: 'evaluation', label: '팀원 평가 요약', value: data.evaluation },
+  ];
+  return (
+    <div className={cn('flex min-h-[330px] max-w-[560px] flex-col justify-center gap-5')}>
+      <div className={cn('flex-wrap flex-center', radialParentClassName)}>
+        {Object.entries(data.radialChartData).map(([type, value]) => (
+          <RadialChart key={type} type={type as RadialEvaluationType} value={value} />
+        ))}
+      </div>
+      <div className="grid grid-cols-[100px_1fr] gap-x-2 gap-y-2">
+        {gridTextData.map((item) => (
+          <div key={item.id} className="contents">
+            <div className="flex text-gray-400 mobile1">{item.label}</div>
+            <div className="flex items-center gap-1 text-gray-800 display5">
+              {!item.value || (Array.isArray(item.value) && item.value.length === 0)
+                ? '-'
+                : item.id === 'keyword' && Array.isArray(item.value)
+                  ? item.value.map((value, index) => (
+                      <TagInput key={index} value={value} isDisabled />
+                    ))
+                  : item.value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const defaultTripleRadialChartData: RadilChartData = {
+  radialChartData: {
+    [RADIAL_EVALUATION_TYPES.LEADERSHIP]: 70,
+    [RADIAL_EVALUATION_TYPES.RELIABILITY]: 80,
+    [RADIAL_EVALUATION_TYPES.TEAMWORK]: 60,
+  },
+  keyword: ['배려', '책임감', '도전정신'],
+  evaluation:
+    '문제점을 바로 파악하고 해결책을 생각하는 문제해결능력이 큰 장점인 사람입니다. 다만 진행상황에 대해 즉시 공유하는 팀워크 능력이 다소 부족하다.',
+};

--- a/src/components/domain/project/projectButton/ProjectImageSaveButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectImageSaveButton.tsx
@@ -17,10 +17,9 @@ export default function ProjectImageSaveButton({ className }: ProjectImageSaveBu
     <div
       onClick={handleProjectImageSave}
       className={cn(
-        'flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current display5',
+        'flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current underline-offset-4 display5',
         className,
-      )}
-      style={{ textUnderlineOffset: '4px' }}>
+      )}>
       <span>이미지로 저장</span>
       <Download className="h-4 w-4" />
     </div>

--- a/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
@@ -34,7 +34,7 @@ export default function ProjectRegisterButton({
       onClick={handleOpenProjectRegisterModal}
       variant="gradient"
       className={cn('h-[60px] w-[250px]', className)}>
-      <ClipboardEdit className="mr-2 h-5 w-5" />
+      <ClipboardEdit className="mr-2 h-6 w-6" />
       <p className="body8">{text}</p>
     </Button>
   );

--- a/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
@@ -25,6 +25,7 @@ export default function ProjectIntroduceCard({
       <section>
         <h2 className="text-gray-900 body6">프로젝트 개요</h2>
         <BorderCard>
+          {/* grid로  */}
           <div></div>
         </BorderCard>
       </section>

--- a/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
@@ -1,17 +1,27 @@
 import BorderCard from '@/components/common/card/BorderCard';
+import { ArrowUpRight } from 'lucide-react';
+import ProjectImageSaveButton from '../projectButton/ProjectImageSaveButton';
+import TagInput from '@/components/common/input/TagInput';
+import ProjectVisibilityButton from '../projectButton/ProjectVisibilityButton';
+import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 
 interface ProjectIntroduceCardProps {
   projectId: number;
-  fromMyProfile?: boolean;
+  userId?: string;
+  fromMyProfile?: boolean; // true: 내 프로젝트 상세조회
 }
 
 // 프로젝트 개요
 export default function ProjectIntroduceCard({
   projectId,
+  userId,
   fromMyProfile = false,
 }: ProjectIntroduceCardProps) {
   // 프로젝트 정보 조회 api 호출
   console.log(fromMyProfile, projectId);
+  if (!fromMyProfile) {
+    console.log(userId);
+  }
   return (
     <div className="flex flex-col gap-10">
       <section className="flex-col-center">
@@ -22,11 +32,49 @@ export default function ProjectIntroduceCard({
           <EmphasizeWord text="기획자" />로 활동한 이지영입니다
         </h1>
       </section>
-      <section>
-        <h2 className="text-gray-900 body6">프로젝트 개요</h2>
-        <BorderCard>
-          {/* grid로  */}
-          <div></div>
+      <section className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-gray-900 body6">프로젝트 개요</h2>
+          {fromMyProfile && <ProjectImageSaveButton className="-mb-4 mr-2" />}
+        </div>
+        <BorderCard className="p-7">
+          <div className="grid grid-cols-[auto_1fr] gap-x-8 gap-y-7">
+            <div className="text-gray-600 display6">기간</div>
+            <div className="text-black display4">2024.5.11 - 2024.7.22</div>
+
+            <div className="text-gray-600 display6">역할</div>
+            <div className="flex items-center gap-1">
+              <TagInput isDisabled colorTheme="indigo" value="기획자" />
+              <TagInput isDisabled colorTheme="indigo" value="디자이너" />
+            </div>
+
+            <div className="text-gray-600 display6">상세설명</div>
+            <p className="text-black display4">
+              이 프로젝트는 웰훕스팅 커뮤니티 이 프로젝트는 웰훕스팅 커뮤니티 스위코에서 주최한 6주
+              단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를 마무리한
+              사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은 프로젝트를 등록하고
+              평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는 것입니다.스위코에서 주최한
+              6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를 마무리한
+              사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은 프로젝트를 등록하고
+              평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는 것입니다.
+            </p>
+
+            <div className="text-purple-800 display6">링크 바로가기</div>
+            <div className="flex items-center justify-between">
+              <div className="flex-center">
+                <a href="PRism.co.kr" className="text-gray-500 underline underline-offset-4">
+                  PRism.co.kr
+                </a>
+                <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
+              </div>
+              {fromMyProfile && (
+                <div className="space-x-2 flex-center">
+                  <ProjectVisibilityButton projectId={projectId} initialVisibility={true} />
+                  <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시돼요." />
+                </div>
+              )}
+            </div>
+          </div>
         </BorderCard>
       </section>
     </div>

--- a/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
@@ -1,0 +1,44 @@
+import BorderCard from '@/components/common/card/BorderCard';
+
+interface ProjectIntroduceCardProps {
+  projectId: number;
+  fromMyProfile?: boolean;
+}
+
+// 프로젝트 개요
+export default function ProjectIntroduceCard({
+  projectId,
+  fromMyProfile = false,
+}: ProjectIntroduceCardProps) {
+  // 프로젝트 정보 조회 api 호출
+  console.log(fromMyProfile, projectId);
+  return (
+    <div className="flex flex-col gap-10">
+      <section className="flex-col-center">
+        <h1 className="text-gray-900 body6">
+          프로젝트
+          <EmphasizeWord text="Prism" />
+          에서
+          <EmphasizeWord text="기획자" />로 활동한 이지영입니다
+        </h1>
+      </section>
+      <section>
+        <h2 className="text-gray-900 body6">프로젝트 개요</h2>
+        <BorderCard>
+          <div></div>
+        </BorderCard>
+      </section>
+    </div>
+  );
+}
+
+interface EmphasizeWordProps {
+  text: string;
+}
+const EmphasizeWord = ({ text }: EmphasizeWordProps) => {
+  return (
+    <span className="relative mx-2 inline-block text-purple-700 body6 before:absolute before:bottom-0 before:left-0 before:h-[1px] before:w-full before:bg-black before:content-[''] after:absolute after:bottom-[-2.5px] after:right-[-5px] after:h-[5px] after:w-[5px] after:rounded-full after:bg-black">
+      {text}
+    </span>
+  );
+};

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -78,7 +78,7 @@ const LeftSection = ({ projectData }: { projectData: ProjectSummaryData }) => (
 
 const EvaluationSection = ({ evaluation }: { evaluation: string }) => (
   <section className="flex flex-col justify-center">
-    <h3 className="text-gray-400 mobile1">한 줄 평가</h3>
+    <h3 className="text-gray-400 mobile1">팀원 평가 요약</h3>
     <p className={cn('overflow-y-auto text-gray-800 display4', evaluation || 'text-gray-300')}>
       {evaluation || '등록된 한 줄 평가가 없습니다.'}
     </p>

--- a/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
+++ b/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
@@ -149,7 +149,10 @@ interface MemberItemProps {
 const MemberItem = ({ member, index, isSelected, onSelect }: MemberItemProps) => {
   const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
   const PlanetIcon = PlanetIcons[planetKeys[index % planetKeys.length]];
-
+  // 아래 기준처럼 데이터 받아서 분기처리 해야함!
+  // - 비회원 : 이름은 보여지고, 이메일은 앞글자 2개 보여지고 @ 뒤는 다 보여짐
+  // - 회원이지만 비공개 처리 : 이름 한글자만 공개, 이메일은 앞글자 2개 보여지고 @ 뒤는 다 보여짐
+  // - 회원이고 공개처리 : 그냥 다 보여짐
   return (
     <>
       <div className="flex w-full items-center gap-[6px]">

--- a/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
+++ b/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
@@ -9,9 +9,15 @@ import { useTagListState } from '@/hooks/useTagListState';
 import SearchInput from '@/components/common/input/SearchInput';
 import { cn } from '@/lib/utils';
 
-export default function ProjectSearchBar() {
+interface ProjectSeqrchBarProps {
+  defaultDetailVisible?: boolean;
+}
+export default function ProjectSearchBar({ defaultDetailVisible = false }: ProjectSeqrchBarProps) {
   const [placeholder, setPlaceholder] = useState('이름 혹은 이메일을 검색해주세요');
-  const [isDetailVisible, toggleDetailVisibility] = useReducer((state) => !state, false);
+  const [isDetailVisible, toggleDetailVisibility] = useReducer(
+    (state) => !state,
+    defaultDetailVisible,
+  );
 
   const { selectList, addSelectList, isSelected, isSelectionLimitReached } = useTagListState([], 5);
 
@@ -69,22 +75,23 @@ export default function ProjectSearchBar() {
           'w-full overflow-hidden transition-all duration-300 ease-in-out',
           isDetailVisible ? 'opacity-100' : 'opacity-0',
         )}>
-        <div className="mt-2 w-full">
-          <div className="flex w-full flex-wrap gap-3">
+        <div className="mt-1 w-full">
+          <div className="flex w-full flex-wrap gap-4">
             <span className="h-9 w-20 rounded-[6px] bg-indigo-50 px-3 py-2 text-center text-indigo-500 display6">
               카테고리
             </span>
-            <div className="flex flex-wrap gap-1">
+            <ul className="flex flex-wrap gap-2">
               {ProjectCategories.map((category) => (
-                <CheckTagInput
-                  key={category}
-                  value={category}
-                  isChecked={isSelected(category)}
-                  isDisabled={isSelectionLimitReached() && !isSelected(category)}
-                  onClick={() => handleCategoryClick(category)}
-                />
+                <li key={category}>
+                  <CheckTagInput
+                    value={category}
+                    isChecked={isSelected(category)}
+                    isDisabled={isSelectionLimitReached() && !isSelected(category)}
+                    onClick={() => handleCategoryClick(category)}
+                  />
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
         </div>
       </div>

--- a/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
+++ b/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
@@ -1,34 +1,25 @@
 'use client';
 
-import { useEffect, useReducer, useState } from 'react';
-import IconInput from '@/components/common/input/IconInput';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Search, User, Clipboard, ChevronDown, ChevronUp } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { useReducer, useState } from 'react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { User, Clipboard, ChevronDown, ChevronUp } from 'lucide-react';
 import { ProjectCategories } from '@/lib/tagList';
 import CheckTagInput from '@/components/common/input/CheckTagInput';
 import { useTagListState } from '@/hooks/useTagListState';
+import SearchInput from '@/components/common/input/SearchInput';
+import { cn } from '@/lib/utils';
 
-interface ProjectSearchBarProps {
-  className?: string;
-}
-
-export default function ProjectSearchBar({ className }: ProjectSearchBarProps) {
+export default function ProjectSearchBar() {
   const [placeholder, setPlaceholder] = useState('이름 혹은 이메일을 검색해주세요');
   const [isDetailVisible, toggleDetailVisibility] = useReducer((state) => !state, false);
 
   const { selectList, addSelectList, isSelected, isSelectionLimitReached } = useTagListState([], 5);
 
-  // 아래는 categories 변화 감지 예시 코드입니다.
-  useEffect(() => {
-    console.log(selectList);
-  }, [selectList]);
-
   const handleValueChange = (value: string) => {
     if (value === 'member') {
       setPlaceholder('이름 혹은 이메일을 검색해 주세요.');
     } else if (value === 'project') {
-      setPlaceholder('프로젝트명을 입력하세요.');
+      setPlaceholder('프로젝트명을 입력해 주세요.');
     }
   };
 
@@ -36,8 +27,16 @@ export default function ProjectSearchBar({ className }: ProjectSearchBarProps) {
     addSelectList(category);
   };
 
+  const handleSearch = (keyword: string) => {
+    if (keyword === '' && selectList.size === 0) {
+      alert('검색어 입력 또는 카테고리를 선택해 주세요.');
+      return;
+    }
+    alert(`keyword: ${keyword}, category: ${JSON.stringify(Array.from(selectList))} 로 검색하기`);
+  };
+
   return (
-    <div className={cn('my-4', className)}>
+    <div className="my-4 w-[60%] gap-2 flex-col-center">
       <Tabs defaultValue="member" onValueChange={handleValueChange}>
         <TabsList>
           <TabsTrigger value="member">
@@ -49,16 +48,13 @@ export default function ProjectSearchBar({ className }: ProjectSearchBarProps) {
             <p className="body8">프로젝트명</p>
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="member">{/* NOTE: 팀원 검색 내용 추가 예정 */}</TabsContent>
-        <TabsContent value="project">{/* NOTE: 프로젝트명 검색 내용을 추가 예정 */}</TabsContent>
       </Tabs>
-
-      <IconInput
-        className="h-[64px] w-full max-w-[700px] pl-14 body8 border-gradient"
-        svgIcon={<Search className="mx-2 h-[24px] w-[24px] text-gray-500" />}
+      <SearchInput
+        className="h-[64px] w-full body8 border-gradient"
         placeholder={placeholder}
+        onSearch={handleSearch}
       />
-      <div className="mt-3 flex items-center body8">
+      <div className="flex w-full items-center body8">
         <button onClick={toggleDetailVisibility} className="flex items-center text-gray-700">
           <span className="mx-1">검색 필터</span>
           {isDetailVisible ? (
@@ -68,31 +64,30 @@ export default function ProjectSearchBar({ className }: ProjectSearchBarProps) {
           )}
         </button>
       </div>
-
-      {isDetailVisible && (
-        <div className="mt-2">
-          {/* NOTE : 태그 회의 후 상세보기 내용 추가 예정 */}
-          {/* #20240710.syjang, CheckTagInput 사용 예시 작성하려 임의로 코드 작성했습니다. 아래는 참고만 부탁드립니다. */}
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-wrap gap-3">
-              <span className="h-9 w-20 rounded-[6px] bg-indigo-50 px-3 py-2 text-center text-indigo-500 display6">
-                카테고리
-              </span>
-              <div className="flex flex-wrap gap-1">
-                {ProjectCategories.map((category) => (
-                  <CheckTagInput
-                    key={category}
-                    value={category}
-                    isChecked={isSelected(category)}
-                    isDisabled={isSelectionLimitReached() && !isSelected(category)}
-                    onClick={() => handleCategoryClick(category)}
-                  />
-                ))}
-              </div>
+      <div
+        className={cn(
+          'w-full overflow-hidden transition-all duration-300 ease-in-out',
+          isDetailVisible ? 'opacity-100' : 'opacity-0',
+        )}>
+        <div className="mt-2 w-full">
+          <div className="flex w-full flex-wrap gap-3">
+            <span className="h-9 w-20 rounded-[6px] bg-indigo-50 px-3 py-2 text-center text-indigo-500 display6">
+              카테고리
+            </span>
+            <div className="flex flex-wrap gap-1">
+              {ProjectCategories.map((category) => (
+                <CheckTagInput
+                  key={category}
+                  value={category}
+                  isChecked={isSelected(category)}
+                  isDisabled={isSelectionLimitReached() && !isSelected(category)}
+                  onClick={() => handleCategoryClick(category)}
+                />
+              ))}
             </div>
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/domain/user/UserProfile.tsx
+++ b/src/components/domain/user/UserProfile.tsx
@@ -39,9 +39,7 @@ export default function UserProfile() {
       </BorderCard>
       <div className="absolute -right-2 -top-7 mr-4">
         <Link href="/mypage/edit">
-          <div
-            className="flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current display5"
-            style={{ textUnderlineOffset: '4px' }}>
+          <div className="flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current underline-offset-4 display5">
             <span>프로필 수정</span>
             <PencilLine className="h-4 w-4" />
           </div>

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -1,37 +1,64 @@
 'use client';
 
+import { cn } from '@/lib/utils';
 import ShadowCard from '@/components/common/card/ShadowCard';
 import TagInput from '@/components/common/input/TagInput';
 import CirclePlanetIcon from './CirclePlanetIcon';
 import { ChevronRight } from 'lucide-react';
+import {
+  USER_CARD_VARIANT,
+  type UserSummaryCardVariant,
+  type UserSummaryData,
+} from '@/models/user/userModels';
+import { maskEmail, maskName } from '@/lib/masking';
 
-export default function UserSummaryCard() {
+interface UserSummaryCard {
+  userData: UserSummaryData;
+  variant?: UserSummaryCardVariant;
+}
+
+export default function UserSummaryCard({
+  userData,
+  variant = USER_CARD_VARIANT.MEMBER_PUBLIC,
+}: UserSummaryCard) {
+  const isPublicUser = variant === USER_CARD_VARIANT.MEMBER_PUBLIC;
   const handleOpenUserProfile = () => {
-    console.log('프로필 보러가기 연결 예정');
+    if (!isPublicUser) return;
+    alert(`${userData.userId}번 유저의 프로필 보러가기`);
   };
 
-  // NOTE: project API 연동 이후 하드코딩된 값 변경 예정
-
   return (
-    <ShadowCard className="flex h-[157px] w-[512px] flex-col justify-between p-6">
+    <ShadowCard
+      className={cn(
+        'flex h-[157px] w-[512px] flex-col justify-between p-6',
+        !isPublicUser && 'cursor-default',
+      )}
+      onClick={handleOpenUserProfile}>
       <div className="flex items-start space-x-4">
         <CirclePlanetIcon className="bg-gray-100" />
         <div className="flex flex-col justify-center">
-          <p className="body8">이지영</p>
-          <p className="text-gray-500 display5">fj298@gmail.com</p>
+          <p className="body8">
+            {variant === USER_CARD_VARIANT.MEMBER_PRIVATE ? maskName(userData.name) : userData.name}
+          </p>
+          <p className="text-gray-500 display5">
+            {isPublicUser ? userData.email : maskEmail(userData.email)}
+          </p>
         </div>
       </div>
       <div className="mt-auto flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <TagInput value="기획자" buttonType="none" colorTheme="indigo" />
-          <TagInput value="디자이너" buttonType="none" colorTheme="indigo" />
-        </div>
-        <div
-          className="cursor-pointer text-gray-600 underline decoration-current underline-offset-4 display5 flex-center"
-          onClick={handleOpenUserProfile}>
-          프로필 보러가기
-          <ChevronRight className="h-4 w-4" />
-        </div>
+        <ul className="flex items-center gap-2">
+          {userData.roles.map((role, index) => (
+            <li key={index}>
+              <TagInput value={role} isDisabled colorTheme="indigo" />
+            </li>
+          ))}
+        </ul>
+        {isPublicUser && (
+          <div className="cursor-pointer text-gray-600 underline decoration-current underline-offset-4 display5 flex-center">
+            프로필 보러가기
+            <ChevronRight className="h-4 w-4" />
+          </div>
+        )}
       </div>
     </ShadowCard>
   );

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -27,8 +27,7 @@ export default function UserSummaryCard() {
           <TagInput value="디자이너" buttonType="none" colorTheme="indigo" />
         </div>
         <div
-          className="cursor-pointer text-gray-600 underline decoration-current display5 flex-center"
-          style={{ textUnderlineOffset: '4px' }}
+          className="cursor-pointer text-gray-600 underline decoration-current underline-offset-4 display5 flex-center"
           onClick={handleOpenUserProfile}>
           프로필 보러가기
           <ChevronRight className="h-4 w-4" />

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { ButtonProps, buttonVariants } from '@/components/ui/button';
+
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn('mx-auto flex w-full justify-center', className)}
+    {...props}
+  />
+);
+Pagination.displayName = 'Pagination';
+
+const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
+  ({ className, ...props }, ref) => (
+    <ul ref={ref} className={cn('flex flex-row items-center gap-1', className)} {...props} />
+  ),
+);
+PaginationContent.displayName = 'PaginationContent';
+
+const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
+  ({ className, ...props }, ref) => <li ref={ref} className={cn('', className)} {...props} />,
+);
+PaginationItem.displayName = 'PaginationItem';
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<ButtonProps, 'size'> &
+  React.ComponentProps<'a'>;
+
+const PaginationLink = ({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? 'page' : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? 'outline' : 'ghost',
+        size,
+      }),
+      className,
+    )}
+    {...props}
+  />
+);
+PaginationLink.displayName = 'PaginationLink';
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn('gap-1 pl-2.5', className)}
+    {...props}>
+    <ChevronLeft className="h-4 w-4" />
+    <span>이전</span>
+  </PaginationLink>
+);
+PaginationPrevious.displayName = 'PaginationPrevious';
+
+const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn('gap-1 pr-2.5', className)}
+    {...props}>
+    <span>다음</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+);
+PaginationNext.displayName = 'PaginationNext';
+
+const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
+  <span
+    aria-hidden
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}>
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+);
+PaginationEllipsis.displayName = 'PaginationEllipsis';
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/src/models/evaluation/evaluationModels.ts
+++ b/src/models/evaluation/evaluationModels.ts
@@ -2,7 +2,7 @@
 export const RADIAL_EVALUATION_TYPES = {
   LEADERSHIP: 'LEADERSHIP',
   RELIABILITY: 'RELIABILITY',
-  CHARISMA: 'CHARISMA',
+  TEAMWORK: 'TEAMWORK',
 } as const;
 
 export type RadialEvaluationType =

--- a/src/models/prism/prismModels.ts
+++ b/src/models/prism/prismModels.ts
@@ -1,13 +1,3 @@
-// 추가 평가 유형 상수 및 관련 정보 정의
-export const RADIAL_EVALUATION_TYPES = {
-  LEADERSHIP: 'LEADERSHIP',
-  RELIABILITY: 'RELIABILITY',
-  TEAMWORK: 'TEAMWORK',
-} as const;
-
-export type RadialEvaluationType =
-  (typeof RADIAL_EVALUATION_TYPES)[keyof typeof RADIAL_EVALUATION_TYPES];
-
 // PRism 평가 유형 상수 및 관련 정보 정의
 export const PRISM_EVALUATIONS = [
   'COMMUNICATION',
@@ -18,7 +8,7 @@ export const PRISM_EVALUATIONS = [
 ] as const;
 export type PRismEvaluationType = (typeof PRISM_EVALUATIONS)[number];
 
-export const EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
+export const PRISM_EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
   COMMUNICATION: '의사소통능력',
   PROACTIVITY: '적극성',
   PROBLEM_SOLVING: '문제해결능력',
@@ -26,7 +16,18 @@ export const EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
   COOPERATION: '협동심',
 };
 
-export interface Evaluation {
+// Prism Chart 데이터
+export interface PRismEvaluation {
   evaluation: PRismEvaluationType;
   percent: number;
 }
+
+// Radial 차트 유형 상수 및 관련 정보 정의
+export const RADIAL_EVALUATIONS = ['LEADERSHIP', 'RELIABILITY', 'TEAMWORK'] as const;
+export type RadialEvaluationType = (typeof RADIAL_EVALUATIONS)[number];
+
+export const RADIAL_EVALUATION_LABELS: Record<RadialEvaluationType, string> = {
+  LEADERSHIP: '리더십',
+  RELIABILITY: '신뢰도',
+  TEAMWORK: '팀워크',
+};

--- a/src/models/prism/prismModels.ts
+++ b/src/models/prism/prismModels.ts
@@ -17,3 +17,16 @@ export const PRISM_EVALUATIONS = [
   'COOPERATION',
 ] as const;
 export type PRismEvaluationType = (typeof PRISM_EVALUATIONS)[number];
+
+export const EVALUATION_LABELS: Record<PRismEvaluationType, string> = {
+  COMMUNICATION: '의사소통능력',
+  PROACTIVITY: '적극성',
+  PROBLEM_SOLVING: '문제해결능력',
+  RESPONSIBILITY: '책임감',
+  COOPERATION: '협동심',
+};
+
+export interface Evaluation {
+  evaluation: PRismEvaluationType;
+  percent: number;
+}

--- a/src/models/user/userModels.ts
+++ b/src/models/user/userModels.ts
@@ -6,3 +6,20 @@ export interface User {
   roles: string[]; // 관심 직무
   skills: string[]; // 보유 스킬
 }
+
+// 유저 요약 카드에 쓰이는 interface
+export interface UserSummaryData {
+  userId: string; // 유저 식별자
+  name: string;
+  email: string;
+  roles: string[];
+}
+
+// 유저 요약 카드 variant
+export const USER_CARD_VARIANT = {
+  NON_MEMBER: 'NonMember', // 비회원 사용자 카드
+  MEMBER_PRIVATE: 'MemberPrivate', // 회원이지만 비공개 설정된 카드
+  MEMBER_PUBLIC: 'MemberPublic', // 회원이며 공개 설정된 카드
+} as const;
+
+export type UserSummaryCardVariant = (typeof USER_CARD_VARIANT)[keyof typeof USER_CARD_VARIANT];


### PR DESCRIPTION
## 💡 ISSUE 번호

#56 

<br/>

## 🔎 작업 내용

- 검색 결과를 통해 들어가는 프로젝트 상세 페이지 스크린 제작
- 마이프로필에서 들어가는 프로젝트 상세 페이지 스크린 제작
- 타인의 프로필에서 들어가는 프로젝트 상세 페이지 스크린 제작
- PRism 분석 리포트 컴포넌트 추가
- RadialChart의 매력도 -> 팀워크로 지표 변경
- 수정된 홈화면 UI 반영 및 클릭 이벤트 연결 (현재 선택값 뽑아내기)
- UserSummaryCard에 variant 추가하여 비회원/공개회원/비공개회원 분기처리
- 검색 결과 스크린 제작, shadcn pagination 컴포넌트 추가
- evaluationModels -> prismModels 로 변경하며 차트 지표 관련 타입들 모아둠


<br/>

## 📢 주의 및 리뷰 요청

- 각 페이지에 api 연동은 아직입니다. 스크린 작업이라도 빨리 끝내고 싶어서, 퍼블리싱 정도로만 진행했습니다! 디테일한 분기처리 없이 하드코딩으로 짜놓은 상태인 점 참고 부탁드립니다!


<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
