### PR TITLE
Feat/#78 프로필의 참여한 프로젝트 리스트 / 프로젝트 상세 조회 api 연동

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,14 +14,14 @@ export default function MyPage() {
           <ProjectRegisterButton text="새 프로젝트 등록하기" className="h-[45px] w-[210px]" />
         </div>
         <h2 className="text-gray-900 body6">프로필</h2>
-        <UserProfile />
+        <UserProfile fromMyProfile />
       </section>
       <section className="relative flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <h2 className="text-gray-900 body6">PRism 종합 리포트</h2>
           <ProjectImageSaveButton className="-mb-4 mr-2" />
         </div>
-        <OverallPRismReport />
+        <OverallPRismReport fromMyProfile />
       </section>
       <section className="flex flex-col gap-3">
         <ParticipatingProjectList fromMyProfile />

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -5,7 +5,11 @@ import GoProjectLinkButton from '@/components/domain/project/projectButton/GoPro
 import ProjectRegisterButton from '@/components/domain/project/projectButton/ProjectRegisterButton';
 import ProjectImageSaveButton from '@/components/domain/project/projectButton/ProjectImageSaveButton';
 
-export default function MyPage() {
+interface UserProfilePageProps {
+  params: { userId: string };
+}
+
+export default function UserProfilePage({ params }: UserProfilePageProps) {
   return (
     <div className="container flex min-h-screen w-full max-w-[1040px] flex-col justify-center gap-6 p-4">
       <section className="flex flex-col gap-3">
@@ -24,7 +28,7 @@ export default function MyPage() {
         <OverallPRismReport />
       </section>
       <section className="flex flex-col gap-3">
-        <ParticipatingProjectList fromMyProfile />
+        <ParticipatingProjectList userId={params.userId} />
       </section>
     </div>
   );

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -1,9 +1,6 @@
 import UserProfile from '@/components/domain/user/UserProfile';
 import OverallPRismReport from '@/components/domain/prism/OverallPRismReport';
 import ParticipatingProjectList from '@/components/domain/project/projectList/ParticipatingProjectList';
-import GoProjectLinkButton from '@/components/domain/project/projectButton/GoProjectLinkButton';
-import ProjectRegisterButton from '@/components/domain/project/projectButton/ProjectRegisterButton';
-import ProjectImageSaveButton from '@/components/domain/project/projectButton/ProjectImageSaveButton';
 
 interface UserProfilePageProps {
   params: { userId: string };
@@ -13,22 +10,17 @@ export default function UserProfilePage({ params }: UserProfilePageProps) {
   return (
     <div className="container flex min-h-screen w-full max-w-[1040px] flex-col justify-center gap-6 p-4">
       <section className="flex flex-col gap-3">
-        <div className="mt-4 flex justify-end gap-4">
-          <GoProjectLinkButton />
-          <ProjectRegisterButton text="새 프로젝트 등록하기" className="h-[45px] w-[210px]" />
-        </div>
         <h2 className="text-gray-900 body6">프로필</h2>
-        <UserProfile />
+        <UserProfile fromMyProfile={false} />
       </section>
       <section className="relative flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <h2 className="text-gray-900 body6">PRism 종합 리포트</h2>
-          <ProjectImageSaveButton className="-mb-4 mr-2" />
         </div>
-        <OverallPRismReport />
+        <OverallPRismReport fromMyProfile={false} />
       </section>
       <section className="flex flex-col gap-3">
-        <ParticipatingProjectList userId={params.userId} />
+        <ParticipatingProjectList userId={params.userId} fromMyProfile={false} />
       </section>
     </div>
   );

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
-// 검색 결과에서 넘어온 프로젝트 상세 조회 페이지
-// 이것도 페이지 전체가 서버에서 받아온 데이터가 필요해서.. nextjs의 fetch를 사용하는게 아니라면 .. ssr이 의미가 없을 것 같습니다..
-// use client 선언해서 사용하는게 좋을 것 같아요
 
+// 검색 결과에서 넘어온 프로젝트 상세 조회 페이지
 import BorderCard from '@/components/common/card/BorderCard';
 import TagInput from '@/components/common/input/TagInput';
+import { ComponentSpinner } from '@/components/common/spinner';
 import UserSummaryCard from '@/components/domain/user/UserSummaryCard';
+import { useGetProfileProjectDetails } from '@/hooks/queries/useProjectService';
+import { convertStringToDate, formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
 import { USER_CARD_VARIANT } from '@/models/user/userModels';
 import { ArrowUpRight, CheckCircle2 } from 'lucide-react';
 
@@ -14,111 +15,140 @@ interface SearchProjectDetailPageProps {
 }
 
 export default function SearchProjectDetailPage({ params }: SearchProjectDetailPageProps) {
-  const projectId = params.projectId;
-  console.log(projectId);
-  const testUserData = {
-    userId: '23fasdf',
-    name: '김프리즘',
-    email: 'rkfhadlwhgdk@naver.com',
-    roles: ['기획자', '디자이너'],
-  };
+  const projectId = Number(params.projectId);
+  const { data, isLoading, isError } = useGetProfileProjectDetails(false, projectId);
+
+  const projectData = data?.data;
+  const isValidData = !(isLoading || isError || !projectData);
+
+  const startDate = convertStringToDate(projectData?.startDate || '2024-07-24'); // 첫 렌더링 시 임시 값으로 설정
+  const endDate = convertStringToDate(projectData?.endDate || '2024-07-24');
+
+  const memberList =
+    projectData?.members?.map((member) => ({
+      ...member,
+      type:
+        member.userId === '-1'
+          ? USER_CARD_VARIANT.NON_MEMBER
+          : !member.anonyVisibility
+            ? USER_CARD_VARIANT.MEMBER_PRIVATE
+            : USER_CARD_VARIANT.MEMBER_PUBLIC,
+    })) || [];
+
+  const renderInvalidText = () => (
+    <span className="text-gray-600 display6 flex-center">
+      {isLoading ? (
+        <ComponentSpinner />
+      ) : isError ? (
+        '프로젝트를 로드하는 중 오류가 발생했습니다.'
+      ) : (
+        '프로젝트 정보가 없습니다.'
+      )}
+    </span>
+  );
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
       <div className="flex w-full max-w-[1040px] flex-col gap-10">
         <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">프로젝트 정보</h2>
           <BorderCard className="flex flex-col justify-center gap-7 p-7">
-            <h3 className="flex flex-col gap-1">
-              <div className="text-gray-500 caption">
-                <span className="text-purple-500 mobile2">적극성</span>이 높은 팀원이 많은 팀의
-                프로젝트에요!
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="text-gray-700 body7">스위그 5기 6팀 팀프로젝트 PRism</span>
-                <span className="gap-1 text-gray-500 caption flex-center">
-                  <CheckCircle2 className="h-4 w-4 fill-success-50 stroke-success-500" />
-                  인증완료!
-                </span>
-              </div>
-            </h3>
-            <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
-              <div className="text-purple-800 display6">링크 바로가기</div>
-              <div className="flex items-center">
-                <a href="PRism.co.kr" className="text-gray-500 underline underline-offset-4">
-                  PRism.co.kr
-                </a>
-                <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
-              </div>
-              <div className="text-gray-600 display6">기관명</div>
-              <div className="text-black display4">스위그</div>
-              <div className="text-gray-600 display6">기간</div>
-              <div className="text-black display4">2024.05.11 - 2024.07.22</div>
-            </div>
+            {!isValidData ? (
+              renderInvalidText()
+            ) : (
+              <>
+                <h3 className="flex flex-col gap-1">
+                  <div className="text-gray-500 caption">
+                    {/* 백엔드에서 데이터를 넘겨줄지 잘 모르겠음. 일단 하드코딩 */}
+                    <span className="text-purple-500 mobile2">적극성</span>이 높은 팀원이 많은 팀의
+                    프로젝트에요!
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-gray-700 body7">{projectData.projectName}</span>
+                    {projectData.projectUrlLink && (
+                      <span className="gap-1 text-gray-500 caption flex-center">
+                        <CheckCircle2 className="h-4 w-4 fill-success-50 stroke-success-500" />
+                        인증완료!
+                      </span>
+                    )}
+                  </div>
+                </h3>
+                <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
+                  <div className="text-purple-800 display6">링크 바로가기</div>
+                  <div className="flex items-center">
+                    {projectData.urlVisibility && projectData.projectUrlLink ? (
+                      <>
+                        <a
+                          href={projectData.projectUrlLink}
+                          className="text-gray-500 underline underline-offset-4">
+                          {projectData.projectUrlLink}
+                        </a>
+                        <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
+                      </>
+                    ) : (
+                      '-'
+                    )}
+                  </div>
+                  <div className="text-gray-600 display6">기관명</div>
+                  <div className="text-black display4">{projectData.organizationName}</div>
+                  <div className="text-gray-600 display6">기간</div>
+                  <div className="text-black display4">
+                    <time>{formatDateToDotSeparatedYYYYMMDD(startDate)}</time> -{' '}
+                    <time>{formatDateToDotSeparatedYYYYMMDD(endDate)}</time>
+                  </div>
+                </div>
+              </>
+            )}
           </BorderCard>
         </section>
         <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">프로젝트 산출물 정보</h2>
           <BorderCard className="p-7">
-            <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
-              <div className="text-gray-600 display6">상세설명</div>
-              <p className="text-black display4">
-                이 프로젝트는 웰훕스팅 커뮤니티 이 프로젝트는 웰훕스팅 커뮤니티 스위코에서 주최한
-                6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를
-                마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은
-                프로젝트를 등록하고 평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는
-                것입니다.스위코에서 주최한 6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다.
-                PRism은 it프로젝트를 마무리한 사람들에게 동료평가 서비스를 제공하는 웹사이트입니다.
-                주요 기능은 프로젝트를 등록하고 평가지를 보내 팀원들의 평가를 받아 5가지의 지표로
-                나타내는 것입니다.
-              </p>
-
-              <div className="text-gray-600 display6">카테고리</div>
-              <ul className="flex gap-2">
-                <li>
-                  {' '}
-                  <TagInput value="금융" isDisabled />
-                </li>
-                <li>
-                  {' '}
-                  <TagInput value="생산성" isDisabled />
-                </li>
-                <li>
-                  {' '}
-                  <TagInput value="기타" isDisabled />
-                </li>
-              </ul>
-
-              <div className="text-gray-600 display6">기술스택</div>
-              <ul className="flex gap-2">
-                <li>
-                  <TagInput value="Spring Framework" isDisabled colorTheme="gray" />
-                </li>
-                <li>
-                  <TagInput value="Python" isDisabled colorTheme="gray" />
-                </li>
-                <li>
-                  <TagInput value="HTML/CSS" isDisabled colorTheme="gray" />
-                </li>
-              </ul>
-            </div>
+            {!isValidData ? (
+              renderInvalidText()
+            ) : (
+              <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
+                <div className="text-gray-600 display6">상세 설명</div>
+                <p className="text-black display4">{projectData.projectDescription || '-'}</p>
+                <div className="text-gray-600 display6">카테고리</div>
+                <ul className="flex gap-2">
+                  {projectData.categories.length === 0
+                    ? '-'
+                    : projectData.categories.map((category, index) => (
+                        <li key={index}>
+                          <TagInput value={category} isDisabled />
+                        </li>
+                      ))}
+                </ul>
+                <div className="text-gray-600 display6">기술스택</div>
+                <ul className="flex flex-wrap gap-2">
+                  {projectData.skills.length === 0
+                    ? '-'
+                    : projectData.skills.map((skill, index) => (
+                        <li key={index}>
+                          <TagInput value={skill} isDisabled colorTheme="gray" />
+                        </li>
+                      ))}
+                </ul>
+              </div>
+            )}
           </BorderCard>
         </section>
         <section className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">팀원 정보</h2>
-          <ul className="flex flex-wrap gap-4">
-            <li>
-              <UserSummaryCard userData={testUserData} />
-            </li>
-            <li>
-              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.NON_MEMBER} />
-            </li>
-            <li>
-              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PRIVATE} />
-            </li>
-            <li>
-              <UserSummaryCard userData={testUserData} variant={USER_CARD_VARIANT.MEMBER_PUBLIC} />
-            </li>
-          </ul>
+          {!isValidData ? (
+            <BorderCard>{renderInvalidText()}</BorderCard>
+          ) : (
+            <ul className="flex flex-wrap gap-4">
+              {
+                /* member의 명확한 식별자가 없어서 key는 index로 사용 */
+                memberList.map((member, index) => (
+                  <li key={index}>
+                    <UserSummaryCard userData={member} variant={member.type} />
+                  </li>
+                ))
+              }
+            </ul>
+          )}
         </section>
       </div>
     </div>

--- a/src/app/project/user/[userId]/[projectId]/page.tsx
+++ b/src/app/project/user/[userId]/[projectId]/page.tsx
@@ -15,13 +15,13 @@ export default function UserProjectDetailPage({ params }: UserProjectDetailPageP
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
       <div className="flex w-full max-w-[1040px] flex-col gap-10">
         {/* 유저 프로필에서 넘어온 상세 조회, Project ID: {projectId} */}
-        <ProjectIntroduceCard userId={userId} projectId={projectId} />
+        <ProjectIntroduceCard userId={userId} projectId={projectId} fromMyProfile={false} />
         <section className="flex flex-col gap-4">
-          <h2 className="text-gray-900 body6">나의 PRism</h2>
+          <h2 className="text-gray-900 body6">PRism</h2>
           <PrismReport />
         </section>
         <section className="flex flex-col gap-4">
-          <h2 className="text-gray-900 body6">나의 PRism 분석 리포트</h2>
+          <h2 className="text-gray-900 body6">PRism 분석 리포트</h2>
           <PrismAnalyzeReport />
         </section>
       </div>

--- a/src/components/common/messgeBox/MessageBox.tsx
+++ b/src/components/common/messgeBox/MessageBox.tsx
@@ -43,16 +43,22 @@ interface MessageBoxButtonProps {
   text: string;
   onClick?: () => void;
   isPrimary?: boolean; // 보라색 강조 버튼 여부
+  isPending?: boolean;
 }
 
-const MessageConfirmButton = ({ text, onClick, isPrimary = true }: MessageBoxButtonProps) => {
+const MessageConfirmButton = ({
+  text,
+  onClick,
+  isPrimary = true,
+  isPending = false,
+}: MessageBoxButtonProps) => {
   const { closeModal } = useModalStore();
   const handleClick = () => {
     closeModal();
     if (onClick) onClick();
   };
   return (
-    <Button variant={isPrimary ? 'default' : 'outline'} onClick={handleClick}>
+    <Button variant={isPrimary ? 'default' : 'outline'} onClick={handleClick} pending={isPending}>
       {text}
     </Button>
   );

--- a/src/components/domain/prism/OverallPRismReport.tsx
+++ b/src/components/domain/prism/OverallPRismReport.tsx
@@ -11,7 +11,7 @@ import ReportBlur from './report/ReportBlur';
 import type { PRismEvaluation } from '@/models/prism/prismModels';
 
 interface OverallPRismReportProps {
-  fromMyProfile?: boolean;
+  fromMyProfile: boolean;
 }
 
 export default function OverallPRismReport({ fromMyProfile }: OverallPRismReportProps) {

--- a/src/components/domain/prism/OverallPRismReport.tsx
+++ b/src/components/domain/prism/OverallPRismReport.tsx
@@ -10,7 +10,11 @@ import TripleRadialChart, {
 import ReportBlur from './report/ReportBlur';
 import type { PRismEvaluation } from '@/models/prism/prismModels';
 
-export default function OverallPRismReport() {
+interface OverallPRismReportProps {
+  fromMyProfile?: boolean;
+}
+
+export default function OverallPRismReport({ fromMyProfile }: OverallPRismReportProps) {
   const [hasData, setHasData] = useState<boolean>(false);
   const [chartData] = useState<PRismEvaluation[]>(defaultPRismChartData);
   const [radialChartData] = useState<RadialChartData>(defaultTripleRadialChartData);
@@ -28,13 +32,13 @@ export default function OverallPRismReport() {
     <BorderCard className="relative flex-wrap gap-8 flex-center">
       {!hasData && <ReportBlur />}
       <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism</div>
+        <div className="text-indigo-800 body6">{fromMyProfile && '나의'} PRism</div>
         <div className="h-full w-full">
           <PRismChart data={chartData} />
         </div>
       </div>
       <div className="flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">
-        <div className="text-indigo-800 body6">나의 PRism 분석 리포트</div>
+        <div className="text-indigo-800 body6">{fromMyProfile && '나의'} PRism 분석 리포트</div>
         <TripleRadialChart data={radialChartData} />
       </div>
     </BorderCard>

--- a/src/components/domain/project/projectButton/ProjectEditDeleteButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEditDeleteButton.tsx
@@ -33,7 +33,7 @@ export default function ProjectEditDeleteButton({ projectId }: ProjectEditDelete
       <button aria-label="삭제" onClick={handleDeleteProject}>
         <Trash2 className="h-6 w-6 stroke-gray-600 stroke-[1.5px] hover:stroke-gray-700 hover:stroke-[2px]" />
       </button>
-      <button aria-label="편집" onClick={handleEditProject}>
+      <button aria-label="편집" disabled={getDetailMutation.isPending} onClick={handleEditProject}>
         <Edit3 className="h-6 w-6 stroke-gray-600 stroke-[1.5px] hover:stroke-gray-700 hover:stroke-[2px]" />
       </button>
     </nav>
@@ -63,7 +63,11 @@ const DeleteConfirmMessage = ({ projectId, closeModal }: DeleteConfirmMessagePro
       footer={
         <>
           <MessageBox.MessageConfirmButton isPrimary={false} text="취소" onClick={handleCancel} />
-          <MessageBox.MessageConfirmButton text="삭제" onClick={handleDelete} />
+          <MessageBox.MessageConfirmButton
+            text="삭제"
+            onClick={handleDelete}
+            isPending={deleteMutaion.isPending}
+          />
         </>
       }
     />

--- a/src/components/domain/project/projectButton/ProjectVisibilityButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectVisibilityButton.tsx
@@ -1,28 +1,31 @@
 'use client';
 
+import { cn } from '@/lib/utils';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { cn } from '@/lib/utils';
 import { useId, useState } from 'react';
+import { useUpdateMyProjectVisibility } from '@/hooks/queries/useProjectService';
 
 interface ProjectVisibilityButtonProps {
   projectId: number;
   initialVisibility: boolean;
 }
-/**
- *
- * @param param0
- * @returns
- */
+
 export default function ProjectVisibilityButton({
   projectId,
   initialVisibility,
 }: ProjectVisibilityButtonProps) {
   const projectVisibilityId = useId();
   const [visibility, setVisibility] = useState<boolean>(initialVisibility);
-  const toggleVisibility = (checked: boolean) => {
+
+  // mutaion의 callback으로 넘겨, 성공시에만 상태가 바뀌게 한다.
+  const handleUpdateVisibility = (checked: boolean) => {
     setVisibility(checked);
-    alert(`로그인 유저의 ${projectId}번 프로젝트 ${checked}로 변경하는 api 호출하기`);
+  };
+
+  const visibilityMuataion = useUpdateMyProjectVisibility(handleUpdateVisibility);
+  const handleClickSwitch = (checked: boolean) => {
+    visibilityMuataion.mutate({ projectId, visibility: checked });
   };
   // 프로젝트 요악 카드의 클릭 이벤트인 상세 조회까지의 이벤트 흐름을 막기 위해 추가
   const handleStopPropagation = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -30,7 +33,7 @@ export default function ProjectVisibilityButton({
   };
   return (
     <div className="flex items-center gap-2" onClick={handleStopPropagation}>
-      <Switch id={projectVisibilityId} checked={visibility} onCheckedChange={toggleVisibility} />
+      <Switch id={projectVisibilityId} checked={visibility} onCheckedChange={handleClickSwitch} />
       <Label htmlFor={projectVisibilityId} className={cn('mobile2', visibility || 'text-gray-400')}>
         {visibility ? '프로젝트 공개' : '프로젝트 비공개'}
       </Label>

--- a/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectIntroduceCard.tsx
@@ -1,83 +1,133 @@
+'use client';
+
 import BorderCard from '@/components/common/card/BorderCard';
 import { ArrowUpRight } from 'lucide-react';
 import ProjectImageSaveButton from '../projectButton/ProjectImageSaveButton';
 import TagInput from '@/components/common/input/TagInput';
 import ProjectVisibilityButton from '../projectButton/ProjectVisibilityButton';
 import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
+import { useGetProfileProjectDetails } from '@/hooks/queries/useProjectService';
+import { useUserStore } from '@/stores/userStore';
+import { PageSpinner } from '@/components/common/spinner';
+import { convertStringToDate, formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
 
 interface ProjectIntroduceCardProps {
   projectId: number;
+  fromMyProfile: boolean; // true: 내 프로젝트 상세조회
   userId?: string;
-  fromMyProfile?: boolean; // true: 내 프로젝트 상세조회
 }
 
 // 프로젝트 개요
 export default function ProjectIntroduceCard({
   projectId,
-  userId,
   fromMyProfile = false,
+  userId = '',
 }: ProjectIntroduceCardProps) {
   // 프로젝트 정보 조회 api 호출
-  console.log(fromMyProfile, projectId);
-  if (!fromMyProfile) {
-    console.log(userId);
-  }
+  const { data, isLoading, isError } = useGetProfileProjectDetails(fromMyProfile, projectId);
+  const loginUser = useUserStore((state) => state.user);
+
+  // 프로젝트 상세 조회 대상자가 누구인지 찾아야함. 대상 id가 없다면 return 처리
+  const targetUserId = fromMyProfile ? loginUser?.userId : userId;
+  if (!targetUserId) return '조회하려는 대상의 상세 프로젝트 정보가 없습니다.';
+  const projectData = data?.data;
+
+  const isValidData = !(isLoading || isError || !projectData);
+
+  const targetUserData = projectData?.members.find((member) => member.userId === targetUserId);
+  const startDate = convertStringToDate(projectData?.startDate || '2024-07-24'); // 첫 렌더링 시 임시 값으로 설정
+  const endDate = convertStringToDate(projectData?.endDate || '2024-07-24');
+
   return (
-    <div className="flex flex-col gap-10">
-      <section className="flex-col-center">
-        <h1 className="text-gray-900 body6">
-          프로젝트
-          <EmphasizeWord text="Prism" />
-          에서
-          <EmphasizeWord text="기획자" />로 활동한 이지영입니다
-        </h1>
-      </section>
-      <section className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+    <>
+      {!isValidData ? (
+        <div className="flex flex-col gap-4">
           <h2 className="text-gray-900 body6">프로젝트 개요</h2>
-          {fromMyProfile && <ProjectImageSaveButton className="-mb-4 mr-2" />}
+          <BorderCard className="h-[165px] w-full flex-col-center">
+            {isLoading ? (
+              <PageSpinner />
+            ) : isError ? (
+              <span className="text-gray-600 display6">
+                프로젝트 정보를 로드하는 중 오류가 발생했습니다.
+              </span>
+            ) : (
+              <span className="text-gray-600 display6">프로젝트 정보가 없습니다.</span>
+            )}
+          </BorderCard>
         </div>
-        <BorderCard className="p-7">
-          <div className="grid grid-cols-[auto_1fr] gap-x-8 gap-y-7">
-            <div className="text-gray-600 display6">기간</div>
-            <div className="text-black display4">2024.5.11 - 2024.7.22</div>
-
-            <div className="text-gray-600 display6">역할</div>
-            <div className="flex items-center gap-1">
-              <TagInput isDisabled colorTheme="indigo" value="기획자" />
-              <TagInput isDisabled colorTheme="indigo" value="디자이너" />
-            </div>
-
-            <div className="text-gray-600 display6">상세설명</div>
-            <p className="text-black display4">
-              이 프로젝트는 웰훕스팅 커뮤니티 이 프로젝트는 웰훕스팅 커뮤니티 스위코에서 주최한 6주
-              단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를 마무리한
-              사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은 프로젝트를 등록하고
-              평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는 것입니다.스위코에서 주최한
-              6주 단기 웹 서비스 출시를 목표로 진행된 프로젝트입니다. PRism은 it프로젝트를 마무리한
-              사람들에게 동료평가 서비스를 제공하는 웹사이트입니다. 주요 기능은 프로젝트를 등록하고
-              평가지를 보내 팀원들의 평가를 받아 5가지의 지표로 나타내는 것입니다.
-            </p>
-
-            <div className="text-purple-800 display6">링크 바로가기</div>
+      ) : (
+        <div className="flex flex-col gap-10">
+          <section className="flex-col-center">
+            <h1 className="text-gray-900 body6">
+              프로젝트
+              <EmphasizeWord text={projectData.projectName} />
+              에서
+              <EmphasizeWord text={targetUserData?.roles.join(', ') || ''} />로 활동한{' '}
+              {targetUserData?.name}입니다.
+            </h1>
+          </section>
+          <section className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
-              <div className="flex-center">
-                <a href="PRism.co.kr" className="text-gray-500 underline underline-offset-4">
-                  PRism.co.kr
-                </a>
-                <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
-              </div>
-              {fromMyProfile && (
-                <div className="space-x-2 flex-center">
-                  <ProjectVisibilityButton projectId={projectId} initialVisibility={true} />
-                  <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시돼요." />
-                </div>
-              )}
+              <h2 className="text-gray-900 body6">프로젝트 개요</h2>
+              {fromMyProfile && <ProjectImageSaveButton className="-mb-4 mr-2" />}
             </div>
-          </div>
-        </BorderCard>
-      </section>
-    </div>
+            <BorderCard className="p-7">
+              <div className="grid grid-cols-[auto_1fr] gap-x-8 gap-y-7">
+                {/* 프로젝트 기간 */}
+                <div className="text-gray-600 display6">기간</div>
+                <div className="text-black display4">
+                  <time>{formatDateToDotSeparatedYYYYMMDD(startDate)}</time> -{' '}
+                  <time>{formatDateToDotSeparatedYYYYMMDD(endDate)}</time>
+                </div>
+
+                {/* 타겟 유저의 해당 프로젝트에서 맡은 역할 */}
+                <div className="text-gray-600 display6">역할</div>
+                <ul className="flex items-center gap-1">
+                  {targetUserData?.roles.map((role, index) => (
+                    <li key={index}>
+                      <TagInput isDisabled colorTheme="indigo" value={role} />
+                    </li>
+                  ))}
+                </ul>
+
+                {/* 프로젝트 설명 */}
+                <div className="text-gray-600 display6">상세 설명</div>
+                <p className="text-black display4">{projectData.projectDescription || '-'}</p>
+
+                <div className="text-purple-800 display6">링크 바로가기</div>
+                <div className="flex items-center justify-between">
+                  {/* 프로젝트 URL */}
+                  <div className="flex-center">
+                    {projectData.urlVisibility && projectData.projectUrlLink ? (
+                      <>
+                        <a
+                          href={projectData.projectUrlLink}
+                          className="text-gray-500 underline underline-offset-4">
+                          {projectData.projectUrlLink}
+                        </a>
+                        <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
+                      </>
+                    ) : (
+                      '-'
+                    )}
+                  </div>
+                  {/* 마이페이지에서 넘어온 경우, 프로젝트 익명 여부 설정 */}
+                  {fromMyProfile && (
+                    <div className="space-x-2 flex-center">
+                      <ProjectVisibilityButton
+                        projectId={projectId}
+                        initialVisibility={targetUserData?.anonyVisibility || false}
+                      />
+                      <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시돼요." />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </BorderCard>
+          </section>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -17,25 +17,29 @@ import {
   type ProjectSummaryData,
 } from '@/models/project/projectModels';
 import { formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
+import { useRouter } from 'next/navigation';
 
 interface ProjectSummaryCardProps {
   projectData: ProjectSummaryData;
+  userId?: string;
   variant?: ProjectSummaryCardVariant;
 }
 
 export default function ProjectSummaryCard({
-  variant = PROJECT_CARD_VARIANT.SEARCH_RESULT,
   projectData,
+  userId = '',
+  variant = PROJECT_CARD_VARIANT.SEARCH_RESULT,
 }: ProjectSummaryCardProps) {
+  const router = useRouter();
   const projectId = projectData.projectId;
   const isCardDisabled =
     variant === PROJECT_CARD_VARIANT.ADMIN || variant === PROJECT_CARD_VARIANT.LINK_PREVIEW;
   const handleClick = () => {
     if (isCardDisabled) return;
     if (variant === PROJECT_CARD_VARIANT.MY_PROFILE) {
-      alert(`로그인한 사용자의 ${projectId}번 프로젝트 상세조회 api 호출하며 페이지 이동`);
+      router.push(`/project/my/${projectId}`);
     } else {
-      alert(`타인의 ${projectId}번 프로젝트 상세조회 api 호출하며 페이지 이동`);
+      router.push(`/project/user/${userId}/${projectId}`);
     }
   };
   return (

--- a/src/components/domain/project/projectList/ParticipatingProjectList.tsx
+++ b/src/components/domain/project/projectList/ParticipatingProjectList.tsx
@@ -68,6 +68,7 @@ export default function ParticipatingProjectList({
                     : PROJECT_CARD_VARIANT.OTHER_PROFILE
                 }
                 projectData={projectData}
+                userId={userId}
               />
             </li>
           ))}

--- a/src/components/domain/project/projectList/ParticipatingProjectList.tsx
+++ b/src/components/domain/project/projectList/ParticipatingProjectList.tsx
@@ -3,7 +3,21 @@ import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 import ProjectSummaryCard from '../projectCard/ProjectSummaryCard';
 import { PROJECT_CARD_VARIANT, type ProjectSummaryData } from '@/models/project/projectModels';
 
-export default function ParticipatingProjectList() {
+interface ParticipatingProjectListProps {
+  userId?: string;
+  fromMyProfile?: boolean;
+}
+
+export default function ParticipatingProjectList({
+  userId,
+  fromMyProfile = false,
+}: ParticipatingProjectListProps) {
+  if (fromMyProfile) {
+    // 내가 등록된 프로젝트 리스트 호출
+  } else {
+    // 타인의 프로젝트 리스트 호출
+    console.log(userId);
+  }
   // TODO: API 연결 예정
   const projectDatas: ProjectSummaryData[] = [
     {

--- a/src/components/domain/project/projectList/ParticipatingProjectList.tsx
+++ b/src/components/domain/project/projectList/ParticipatingProjectList.tsx
@@ -1,52 +1,43 @@
+'use client';
+
 import BorderCard from '@/components/common/card/BorderCard';
 import InformationTooltip from '@/components/common/tooltip/InformationTooltip';
 import ProjectSummaryCard from '../projectCard/ProjectSummaryCard';
 import { PROJECT_CARD_VARIANT, type ProjectSummaryData } from '@/models/project/projectModels';
+import { useGetParticipatingProjects } from '@/hooks/queries/useProjectService';
+import { convertStringToDate } from '@/lib/dateTime';
+import { ComponentSpinner } from '@/components/common/spinner';
 
 interface ParticipatingProjectListProps {
   userId?: string;
-  fromMyProfile?: boolean;
+  fromMyProfile: boolean;
 }
 
 export default function ParticipatingProjectList({
-  userId,
-  fromMyProfile = false,
+  userId = '',
+  fromMyProfile,
 }: ParticipatingProjectListProps) {
-  if (fromMyProfile) {
-    // 내가 등록된 프로젝트 리스트 호출
-  } else {
-    // 타인의 프로젝트 리스트 호출
-    console.log(userId);
-  }
-  // TODO: API 연결 예정
-  const projectDatas: ProjectSummaryData[] = [
-    {
-      projectId: 1,
-      projectname: '이름이름이름1',
-      startDate: new Date(),
-      endDate: new Date(),
-      evaluation: '평가평가평가1',
-      projectVisibility: true,
-    },
-    {
-      projectId: 2,
-      projectname: '이름이름이름2',
-      startDate: new Date(),
-      endDate: new Date(),
-      evaluation:
-        '평가평가평가평가평가평가아주긴평가평가평가평가아주긴평가평가평가평가아주긴평가아주긴평가',
-      projectVisibility: true,
-    },
-    {
-      projectId: 3,
-      organizationName: '스위프',
-      projectname: '이름이름이름긴이름긴이름긴이름',
-      startDate: new Date(),
-      endDate: new Date(),
-      evaluation: '평가평가평가',
-      projectVisibility: false,
-    },
-  ];
+  // 타인 참여 프로젝트 리스트 조회인데 userId가 넘어오지 않은 경우 빈값으로 보내줘서 쿼리 조건이 유효하지 않게 처리
+  const { data, isLoading, isError } = useGetParticipatingProjects(fromMyProfile, userId);
+
+  const projectList = data?.data;
+  const projectDatas: ProjectSummaryData[] = !projectList
+    ? []
+    : projectList.map((project) => {
+        return {
+          projectId: project.projectId,
+          projectname: project.projectName,
+          startDate: convertStringToDate(project.startDate),
+          endDate: convertStringToDate(project.endDate),
+          organizationName: project.organizationName,
+          categories: project.categories,
+          evaluatedMembersCount: project.surveyParcitipants,
+          projectVisibility: false, // 임시로 넣음
+        };
+      });
+
+  // 데이터가 정상적으로 가지고와진 상태인지 판단하여 다른 컴포넌트를 보여준다.
+  const isValidData = !(isLoading || projectDatas.length === 0 || isError);
 
   return (
     <>
@@ -54,16 +45,28 @@ export default function ParticipatingProjectList({
         <h2 className="text-gray-900 body6">프로젝트 목록</h2>
         <InformationTooltip message="프로젝트 참여 비공개로 전환 시, 해당 프로젝트에 '익명'으로 표시돼요." />
       </div>
-      {projectDatas.length === 0 ? (
+      {!isValidData ? (
         <BorderCard className="h-[165px] w-full flex-col-center">
-          <span className="text-gray-600 display6">등록된 프로젝트가 없습니다.</span>
+          {isLoading ? (
+            <ComponentSpinner />
+          ) : isError ? (
+            <span className="text-gray-600 display6">
+              참여 프로젝트를 로드하는 중 오류가 발생했습니다.
+            </span>
+          ) : (
+            <span className="text-gray-600 display6">참여한 프로젝트가 없습니다.</span>
+          )}
         </BorderCard>
       ) : (
         <ul className="flex flex-col gap-4">
           {projectDatas.map((projectData, index) => (
             <li key={index}>
               <ProjectSummaryCard
-                variant={PROJECT_CARD_VARIANT.MY_PROFILE}
+                variant={
+                  fromMyProfile
+                    ? PROJECT_CARD_VARIANT.MY_PROFILE
+                    : PROJECT_CARD_VARIANT.OTHER_PROFILE
+                }
                 projectData={projectData}
               />
             </li>

--- a/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
+++ b/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
@@ -162,6 +162,8 @@ export default function ProjectRegisterModal({
           handlePrevStep={handlePrevStep}
           handleNextStep={handleNextStep}
           handleExternalSubmit={handleExternalSubmit}
+          isEdit={isEdit}
+          isPending={updateMutation.isPending || createMutation.isPending}
           MAX_STEP={MAX_STEP}
         />
       }>

--- a/src/components/domain/project/projectRegisterModal/layout/ProjectRegisterFooter.tsx
+++ b/src/components/domain/project/projectRegisterModal/layout/ProjectRegisterFooter.tsx
@@ -7,6 +7,8 @@ interface ProjectRegisterFooterProps {
   handleNextStep: () => void;
   handleExternalSubmit: () => void;
   MAX_STEP: number;
+  isPending: boolean;
+  isEdit: boolean;
 }
 
 export default function ProjectRegisterFooter({
@@ -15,6 +17,8 @@ export default function ProjectRegisterFooter({
   handleNextStep,
   handleExternalSubmit,
   MAX_STEP,
+  isPending,
+  isEdit,
 }: ProjectRegisterFooterProps) {
   const getButtonClass = (isEnabled: boolean) =>
     `h-10 w-10 stroke-[1.5px] ${isEnabled ? 'cursor-pointer' : 'cursor-not-allowed text-gray-400'}`;
@@ -37,8 +41,8 @@ export default function ProjectRegisterFooter({
         </div>
         <div className="flex flex-1 justify-end">
           {isLastStep && (
-            <Button onClick={handleExternalSubmit} className="mobile1">
-              등록하기
+            <Button onClick={handleExternalSubmit} pending={isPending} className="mobile1">
+              {isEdit ? '수정하기' : '등록하기'}
             </Button>
           )}
         </div>

--- a/src/components/domain/user/UserProfile.tsx
+++ b/src/components/domain/user/UserProfile.tsx
@@ -6,7 +6,11 @@ import BorderCard from '@/components/common/card/BorderCard';
 import CirclePlanetIcon from './CirclePlanetIcon';
 import { PencilLine } from 'lucide-react';
 
-export default function UserProfile() {
+interface UserProfileProps {
+  fromMyProfile: boolean;
+}
+
+export default function UserProfile({ fromMyProfile }: UserProfileProps) {
   const userData = useUserStore((state) => state.user);
 
   const profileData = [
@@ -37,14 +41,16 @@ export default function UserProfile() {
           ))}
         </div>
       </BorderCard>
-      <div className="absolute -right-2 -top-7 mr-4">
-        <Link href="/mypage/edit">
-          <div className="flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current underline-offset-4 display5">
-            <span>프로필 수정</span>
-            <PencilLine className="h-4 w-4" />
-          </div>
-        </Link>
-      </div>
+      {fromMyProfile && (
+        <div className="absolute -right-2 -top-7 mr-4">
+          <Link href="/mypage/edit">
+            <div className="flex cursor-pointer items-center space-x-1 text-gray-800 underline decoration-current underline-offset-4 display5">
+              <span>프로필 수정</span>
+              <PencilLine className="h-4 w-4" />
+            </div>
+          </Link>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -1,16 +1,20 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import ShadowCard from '@/components/common/card/ShadowCard';
 import TagInput from '@/components/common/input/TagInput';
-import CirclePlanetIcon from './CirclePlanetIcon';
+import ShadowCard from '@/components/common/card/ShadowCard';
 import { ChevronRight } from 'lucide-react';
+import CirclePlanetIcon from './CirclePlanetIcon';
+
 import {
   USER_CARD_VARIANT,
   type UserSummaryCardVariant,
   type UserSummaryData,
 } from '@/models/user/userModels';
 import { maskEmail, maskName } from '@/lib/masking';
+
+import { useRouter } from 'next/navigation';
+import { useUserStore } from '@/stores/userStore';
 
 interface UserSummaryCard {
   userData: UserSummaryData;
@@ -21,10 +25,18 @@ export default function UserSummaryCard({
   userData,
   variant = USER_CARD_VARIANT.MEMBER_PUBLIC,
 }: UserSummaryCard) {
+  const router = useRouter();
+  const user = useUserStore((state) => state.user);
   const isPublicUser = variant === USER_CARD_VARIANT.MEMBER_PUBLIC;
+
   const handleOpenUserProfile = () => {
     if (!isPublicUser) return;
-    alert(`${userData.userId}번 유저의 프로필 보러가기`);
+    if (user?.userId === userData.userId) {
+      // 클릭한 유저카드가 나의 카드라면, 마이 페이지로 이동
+      router.push('/mypage');
+    } else {
+      router.push(`/profile/${userData.userId}`);
+    }
   };
 
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -54,7 +54,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {pending && (
           <div className="absolute inset-0 flex items-center justify-center p-3">
             <svg
-              className="h-full w-fit animate-spin text-white"
+              className={cn(
+                'h-full w-fit animate-spin',
+                variant === 'outline' ? 'text-purple-900' : 'text-white',
+              )}
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24">

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -1,13 +1,12 @@
 import { convertStringToDate, formatYYYYMMDDHHmmssToYYYYMMDD } from '@/lib/dateTime';
 import type {
-  RegisteredProjectsResponse,
+  ProjectListResponse,
   ProjectCreateRequest,
   ProjectCreateResponse,
   ProjectDeleteResponse,
   ProjectUpdateRequest,
   ProjectUpdateResponse,
   ProjectDetailResponse,
-  LinkProjectResponse,
 } from '@/models/project/projectApiModels';
 import { ProjectForm } from '@/models/project/projectModels';
 import {
@@ -32,7 +31,7 @@ export const useCreateProject = (successCallback: () => void) => {
 
       // 등록 프로젝트 리스트의 ui 변경을 위해 캐시된 데이터를 직접 수정 (서버 데이터를 refetch 하지 않기 위해 추가)
       // 등록 프로젝트 관리 페이지에서 새 프로젝트를 등록하면 UI도 갱신되어야 한다.
-      queryClient.setQueryData<RegisteredProjectsResponse>(['getRegisteredProjects'], (oldData) => {
+      queryClient.setQueryData<ProjectListResponse>(['getRegisteredProjects'], (oldData) => {
         if (!oldData) return oldData;
 
         // 새 등록 프로젝트 객체 생성
@@ -44,7 +43,7 @@ export const useCreateProject = (successCallback: () => void) => {
           endDate: requestProjectData.endDate,
           categories: requestProjectData.categories,
           surveyParcitipants: 0, // 새로 생성된 프로젝트이므로 참여자는 0으로 초기화
-          visibility: true, // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
+          urlVisibility: true, // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
           userEvaluation: '', // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
         };
         return {
@@ -72,7 +71,7 @@ export const useDeleteProject = (successCallback: () => void) => {
       console.log(response);
 
       // 등록 프로젝트 리스트의 ui 변경을 위해 캐시된 데이터를 직접 수정 (서버 데이터를 refetch 하지 않기 위해 추가)
-      queryClient.setQueryData<RegisteredProjectsResponse>(['getRegisteredProjects'], (oldData) => {
+      queryClient.setQueryData<ProjectListResponse>(['getRegisteredProjects'], (oldData) => {
         if (!oldData) return oldData;
         return {
           ...oldData,
@@ -100,10 +99,8 @@ export const useUpdateProject = (successCallback: () => void) => {
   >({
     mutationFn: ({ projectId, data }) => updateProject(projectId, data),
     onSuccess: (response, { projectId, data }) => {
-      console.log(response);
-
       // 등록 프로젝트 관리 페이지에서 프로젝트를 수정하면 UI도 갱신되어야 한다.
-      queryClient.setQueryData<RegisteredProjectsResponse>(['getRegisteredProjects'], (oldData) => {
+      queryClient.setQueryData<ProjectListResponse>(['getRegisteredProjects'], (oldData) => {
         if (!oldData) return oldData;
         return {
           ...oldData,
@@ -162,7 +159,7 @@ export const useGetProjectDetails = (successCallback: (projectDetailData: Projec
 
 // 내가 등록한 프로젝트 리스트 가져오기
 export const useGetRegisteredProjects = () => {
-  return useQuery<RegisteredProjectsResponse, AxiosError>({
+  return useQuery<ProjectListResponse, AxiosError>({
     queryKey: ['getRegisteredProjects'],
     queryFn: () => getRegisteredProjects(),
   });
@@ -170,7 +167,7 @@ export const useGetRegisteredProjects = () => {
 
 // 프로젝트 이름으로 연동할 프로젝트 리스트 가져오기
 export const useGetLinkProjectsByProjectName = (projectName: string) => {
-  return useQuery<LinkProjectResponse, AxiosError>({
+  return useQuery<ProjectListResponse, AxiosError>({
     queryKey: ['getLinkProjectsByProjectName', projectName],
     queryFn: () => getLinkProjectsByProjectName(projectName),
     enabled: !!projectName, // projectName이 존재할 때만 쿼리 실행

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -170,12 +170,14 @@ export const useGetProjectDetails = (successCallback: (projectDetailData: Projec
 };
 
 // 특정 프로젝트에서 본인의 익명 처리 여부 설정 (공개/비공개)
-export const useUpdateMyProjectVisibility = () => {
+export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean) => void) => {
   return useMutation<MyProjectVisibilityResponse, AxiosError, MyProjectVisibilityRequest>({
     mutationFn: updateMyProjectVisibility,
-    onSuccess: (response) => {
+    onSuccess: (response, requsetCondition) => {
       console.log(response);
-      // 알림 안띄워도 될 것 같음.
+      // 성공 시 알림 안띄워도 될 것 같음. 개발 확인용으로 alert 넣기
+      alert(`프로젝트를 ${requsetCondition.visibility ? '공개하도록' : '익명으로'} 설정했습니다.`);
+      if (successCallback) successCallback(requsetCondition.visibility);
     },
     onError: (error) => {
       alert('프로젝트 공개 설정에 실패했습니다.');

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -35,7 +35,6 @@ import { AxiosError } from 'axios';
 // 프로젝트 생성하기
 export const useCreateProject = (successCallback: () => void) => {
   const queryClient = useQueryClient();
-
   return useMutation<ProjectCreateResponse, AxiosError, ProjectCreateRequest>({
     mutationFn: createProject,
     onSuccess: (response, requestProjectData) => {
@@ -51,8 +50,8 @@ export const useCreateProject = (successCallback: () => void) => {
           projectId: response.data.projectId, // 서버 응답에서 새 프로젝트 ID를 받아옴
           projectName: requestProjectData.projectName,
           organizationName: requestProjectData.organizationName,
-          startDate: requestProjectData.startDate,
-          endDate: requestProjectData.endDate,
+          startDate: formatYYYYMMDDHHmmssToYYYYMMDD(requestProjectData.startDate),
+          endDate: formatYYYYMMDDHHmmssToYYYYMMDD(requestProjectData.endDate),
           categories: requestProjectData.categories,
           surveyParcitipants: 0, // 새로 생성된 프로젝트이므로 참여자는 0으로 초기화
           urlVisibility: true, // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
@@ -63,6 +62,9 @@ export const useCreateProject = (successCallback: () => void) => {
           data: [newProject, ...oldData.data],
         };
       });
+
+      // 참여 프로젝트 리스트 무효화 (setQueryData가 적용이 안되어 처리)
+      queryClient.invalidateQueries({ queryKey: ['getParticipatingProjects'] });
 
       if (successCallback) successCallback();
     },
@@ -244,7 +246,7 @@ export const useGetParticipatingProjects = (fromMyProfile: boolean, userId: stri
 // 나 또는 타인의 프로젝트 상세 조회하기
 export const useGetProfileProjectDetails = (fromMyProfile: boolean, projectID: number) => {
   return useQuery<ProjectDetailResponse, AxiosError>({
-    queryKey: ['getParticipatingProjects', projectID, fromMyProfile],
+    queryKey: ['getProfileProjectDetails', projectID, fromMyProfile],
     queryFn: () => (fromMyProfile ? getMyProjectDetails(projectID) : getProjectDetails(projectID)),
     enabled: !!projectID, // projectID가 존재할 때만 쿼리 실행
   });

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -230,7 +230,7 @@ export const useGetLinkProjectsByProjectName = (projectName: string) => {
   });
 };
 
-// 프로필 별 로그인 유저 혹은 타인의 참여 프로젝트 리스트 가져오기
+// 프로필 별 로그인 유저 혹은 타인의 참여한 프로젝트 리스트 가져오기
 export const useGetParticipatingProjects = (fromMyProfile: boolean, userId: string) => {
   return useQuery<ProjectListResponse, AxiosError>({
     queryKey: ['getParticipatingProjects', userId, fromMyProfile],

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -1,4 +1,4 @@
-import { format, parse } from 'date-fns';
+import { format, fromUnixTime, parse } from 'date-fns';
 import { ko } from 'date-fns/locale/ko';
 
 /**
@@ -57,4 +57,20 @@ export const convertStringToDate = (dateString: string): Date => {
   }
 
   return parsedDate;
+};
+
+/**
+ * Unix 타임스탬프(밀리초)를 "yyyy-MM-dd" 형태의 문자열로 변환
+ * @param timestamp Unix 타임스탬프 (밀리초)
+ * @returns "yyyy-MM-dd" 형태의 문자열
+ */
+export const convertTimestampToDateString = (timestamp: number): string => {
+  try {
+    // 밀리초를 초로 변환
+    const date = fromUnixTime(timestamp / 1000);
+    return format(date, 'yyyy-MM-dd');
+  } catch (error) {
+    console.error('Invalid timestamp provided', error);
+    return format(new Date(), 'yyyy-MM-dd'); // 오류 발생 시, 오늘 날짜를 문자열로 반환
+  }
 };

--- a/src/lib/dateTime.ts
+++ b/src/lib/dateTime.ts
@@ -60,7 +60,7 @@ export const convertStringToDate = (dateString: string): Date => {
 };
 
 /**
- * Unix 타임스탬프(밀리초)를 "yyyy-MM-dd" 형태의 문자열로 변환
+ * Unix 타임스탬프(밀리초)를 "yyyy-MM-dd" 형태의 문자열로 변환 (프로젝트 검색에서 사용)
  * @param timestamp Unix 타임스탬프 (밀리초)
  * @returns "yyyy-MM-dd" 형태의 문자열
  */

--- a/src/models/project/projectApiModels.ts
+++ b/src/models/project/projectApiModels.ts
@@ -148,3 +148,36 @@ export interface ProjectDetailResponse {
     anonymousCount: number;
   };
 }
+
+// 본인이 참여한 프로젝트의 본인 익명 여부
+export interface MyProjectVisibilityResponse {
+  projectId: number;
+  visibility: boolean;
+}
+
+// 프로젝트 검색 요청
+export interface ProjectSearchRequest {
+  searchType: 'MEMBER_NAME' | 'PROJECT_NAME';
+  searchWord: string;
+  categories: number[]; // 상세 검색 필터, category별 id
+  pageNo: number; // 페이지 번호 0부터 시작 (필수), 페이지 번호는 백엔드에서 0부터 시작하기 때문에 프론트 상에 현재 페이지가 2라면 1을 보내야함
+  pageSize: number; // 한 페이지에 나올 개수 (필수)
+}
+// 프로젝트 검색 응답
+export interface ProjectSearchResponse {
+  success: boolean;
+  status: number;
+  data: {
+    totalCount: number;
+    totalPages: number;
+    currentPage: number;
+    contents: {
+      projectId: number;
+      projectName: string;
+      organizationName: string;
+      categories: string[];
+      startDate: number; // 타임스태프 형태
+      endDate: number; // 타임스태프 형태
+    }[];
+  };
+}

--- a/src/models/project/projectApiModels.ts
+++ b/src/models/project/projectApiModels.ts
@@ -70,7 +70,7 @@ export interface ProjectUpdateRequest {
     name: string;
     email: string;
     roles: string[];
-    anonyVisibility: boolean; // 조회 시 받은 데이터 그대로 돌려줘야할듯
+    anonyVisibility?: boolean; // put api여서 일단 필수값은 아니게 처리
   }[];
 }
 export interface ProjectUpdateResponse {

--- a/src/models/project/projectApiModels.ts
+++ b/src/models/project/projectApiModels.ts
@@ -150,6 +150,10 @@ export interface ProjectDetailResponse {
 }
 
 // 본인이 참여한 프로젝트의 본인 익명 여부
+export interface MyProjectVisibilityRequest {
+  projectId: number;
+  visibility: boolean;
+}
 export interface MyProjectVisibilityResponse {
   projectId: number;
   visibility: boolean;
@@ -180,4 +184,10 @@ export interface ProjectSearchResponse {
       endDate: number; // 타임스태프 형태
     }[];
   };
+}
+
+// 프로젝트 연동 요청
+export interface LinkProjectRequest {
+  projectId: number;
+  anonymousEmail: string;
 }

--- a/src/models/project/projectApiModels.ts
+++ b/src/models/project/projectApiModels.ts
@@ -7,7 +7,7 @@ interface CategoryResponse {
   };
 }
 
-// 프로젝트 등록
+// 프로젝트 등록 요청
 export interface ProjectCreateRequest {
   projectName: string;
   organizationName: string;
@@ -34,14 +34,19 @@ export interface ProjectCreateResponse {
 
     projectName: string;
     organizationName: string;
-    startDate: string;
-    endDate: string;
+
     memberCount: number;
-    projectUrlLink: string;
     projectDescription: string;
     skills: string[];
 
     categories: CategoryResponse[];
+
+    startDate: string;
+    endDate: string;
+
+    projectUrlLink: string;
+    urlVisibility: boolean;
+    createdBy: string | null;
   };
 }
 
@@ -49,20 +54,23 @@ export interface ProjectCreateResponse {
 // 프로젝트 산출물의 공개, 비공개 여부 추가 필요
 export interface ProjectUpdateRequest {
   projectName: string;
-  organizationName: string;
-  startDate: string;
-  endDate: string;
-  memberCount: number;
-  projectUrlLink: string;
   projectDescription: string;
+  organizationName: string;
+  memberCount: number;
+  categories: string[];
   skills: string[];
 
-  categories: string[];
+  startDate: string;
+  endDate: string;
+
+  projectUrlLink: string;
+  // urlVisibility: boolean;
 
   members: {
     name: string;
     email: string;
     roles: string[];
+    anonyVisibility: boolean; // 조회 시 받은 데이터 그대로 돌려줘야할듯
   }[];
 }
 export interface ProjectUpdateResponse {
@@ -70,17 +78,18 @@ export interface ProjectUpdateResponse {
   status: number;
   data: {
     projectId: number;
-
     projectName: string;
-    organizationName: string;
-    startDate: string;
-    endDate: string;
-    memberCount: number;
-    projectUrlLink: string;
     projectDescription: string;
+    organizationName: string;
+    memberCount: number;
+    categories: CategoryResponse[];
     skills: string[];
 
-    categories: CategoryResponse[];
+    startDate: string;
+    endDate: string;
+    projectUrlLink: string;
+    // urlVisibility: boolean;
+    createdBy: string | null;
   };
 }
 
@@ -91,8 +100,9 @@ export interface ProjectDeleteResponse {
   data: null;
 }
 
-// 등록한 프로젝트 리스트 가져오기
-export interface RegisteredProjectsResponse {
+// 프로젝트 리스트 받아올 때 Response 형태
+// 내가 참여한 프로젝트 리스트, 내가 등록한 프로젝트 리스트, 연동할 프로젝트 리스트, 타인이 참여한 프로젝트 리스트
+export interface ProjectListResponse {
   success: boolean;
   status: number;
   data: {
@@ -105,29 +115,9 @@ export interface RegisteredProjectsResponse {
 
     categories: string[];
 
-    surveyParcitipants: number;
-    visibility: boolean; // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
-    userEvaluation: string; // 필요 없지만 서버 데이터 형태를 맞추기 위해 추가한 필드
-  }[];
-}
-
-// 연동할 프로젝트 리스트 가져오기
-export interface LinkProjectResponse {
-  success: boolean;
-  status: number;
-  data: {
-    projectId: number;
-
-    projectName: string;
-    organizationName: string;
-    startDate: string;
-    endDate: string;
-
-    categories: string[];
-
-    surveyParcitipants: number;
+    urlVisibility: boolean;
     userEvaluation: string;
-    visibility: boolean;
+    surveyParcitipants: number;
   }[];
 }
 
@@ -143,15 +133,17 @@ export interface ProjectDetailResponse {
     endDate: string;
 
     projectUrlLink: string;
-    visibility: boolean;
+    urlVisibility: boolean;
 
     projectDescription: string;
     categories: string[];
     skills: string[];
     members: {
+      userId: string;
       name: string;
       email: string;
       roles: string[];
+      anonyVisibility: boolean;
     }[];
     anonymousCount: number;
   };

--- a/src/services/api/projectApi.ts
+++ b/src/services/api/projectApi.ts
@@ -6,9 +6,8 @@ import type {
   ProjectUpdateRequest,
   ProjectUpdateResponse,
   ProjectDeleteResponse,
-  RegisteredProjectsResponse,
+  ProjectListResponse,
   ProjectDetailResponse,
-  LinkProjectResponse,
 } from '@/models/project/projectApiModels';
 
 // 프로젝트 등록
@@ -69,11 +68,9 @@ export const deleteProject = async (projectId: number): Promise<ProjectDeleteRes
 };
 
 // 내가 등록한 프로젝트 목록 가져오기
-export const getRegisteredProjects = async (): Promise<RegisteredProjectsResponse> => {
+export const getRegisteredProjects = async (): Promise<ProjectListResponse> => {
   try {
-    const response = await ax.get<RegisteredProjectsResponse>(
-      `/api/v1/projects/me-registered-projects`,
-    );
+    const response = await ax.get<ProjectListResponse>(`/api/v1/projects/me-registered-projects`);
     console.log('Get Registered Project Response:', response.data);
     return response.data;
   } catch (error) {
@@ -95,9 +92,9 @@ export const getRegisteredProjects = async (): Promise<RegisteredProjectsRespons
 // 연동할 프로젝트 목록 가져오기
 export const getLinkProjectsByProjectName = async (
   projectName: string,
-): Promise<LinkProjectResponse> => {
+): Promise<ProjectListResponse> => {
   try {
-    const response = await ax.get<LinkProjectResponse>('/api/v1/projects/summary/by-name', {
+    const response = await ax.get<ProjectListResponse>('/api/v1/projects/summary/by-name', {
       params: { projectName },
     });
 

--- a/src/services/api/projectApi.ts
+++ b/src/services/api/projectApi.ts
@@ -8,6 +8,9 @@ import type {
   ProjectDeleteResponse,
   ProjectListResponse,
   ProjectDetailResponse,
+  MyProjectVisibilityResponse,
+  ProjectSearchRequest,
+  ProjectSearchResponse,
 } from '@/models/project/projectApiModels';
 
 // 프로젝트 등록
@@ -67,29 +70,7 @@ export const deleteProject = async (projectId: number): Promise<ProjectDeleteRes
   }
 };
 
-// 내가 등록한 프로젝트 목록 가져오기
-export const getRegisteredProjects = async (): Promise<ProjectListResponse> => {
-  try {
-    const response = await ax.get<ProjectListResponse>(`/api/v1/projects/me-registered-projects`);
-    console.log('Get Registered Project Response:', response.data);
-    return response.data;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      console.error(
-        `등록한 프로젝트 가져오기 실패: ${error.response?.data?.message || error.message}`,
-      );
-      console.error('Full error response:', error.response?.data);
-      throw new Error(
-        `등록한 프로젝트 가져오기 실패: ${error.response?.data?.message || error.message}`,
-      );
-    } else {
-      console.error(`등록한 프로젝트 가져오기 실패: ${error}`);
-      throw new Error(`등록한 프로젝트 가져오기 실패: ${error}`);
-    }
-  }
-};
-
-// 연동할 프로젝트 목록 가져오기
+// 연동할 프로젝트 리스트 이름으로 가져오기
 export const getLinkProjectsByProjectName = async (
   projectName: string,
 ): Promise<ProjectListResponse> => {
@@ -116,15 +97,128 @@ export const getLinkProjectsByProjectName = async (
   }
 };
 
-// 프로젝트 수정 시에 가져올 상세 값들 (Mutation)
-// 따로 나온 게 없어 재사용 ..
+// 내가 등록한 프로젝트 리스트 가져오기 (프로젝트 관리에서 사용)
+export const getRegisteredProjects = async (): Promise<ProjectListResponse> => {
+  try {
+    const response = await ax.get<ProjectListResponse>(`/api/v1/projects/me-registered-projects`);
+    console.log('Get Registered Project Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `등록한 프로젝트 가져오기 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `등록한 프로젝트 가져오기 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`등록한 프로젝트 가져오기 실패: ${error}`);
+      throw new Error(`등록한 프로젝트 가져오기 실패: ${error}`);
+    }
+  }
+};
+
+// 내가 포함된 프로젝트 리스트 가져오기 (마이 프로필 프로젝트 목록)
+export const getMeInvolvedProjects = async (): Promise<ProjectListResponse> => {
+  try {
+    const response = await ax.get<ProjectListResponse>('/api/v1/projects/me-involved-projects');
+    console.log('Get MeInvolved Project List Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `내가 포함된 프로젝트 리스트 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `내가 포함된 프로젝트 리스트 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`내가 포함된 프로젝트 리스트 조회 실패: ${error}`);
+      throw new Error(`내가 포함된 프로젝트 리스트 조회: ${error}`);
+    }
+  }
+};
+
+// 타인이 포함된 프로젝트 리스트 가져오기 (타인 프로필 프로젝트 목록)
+export const getWhoInvolvedProjects = async (userId: string): Promise<ProjectListResponse> => {
+  try {
+    const response = await ax.get<ProjectListResponse>('/api/v1/projects/who-involved-projects', {
+      params: { userId },
+    });
+    console.log('Get Who Invorved List Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `타인이 포함된 프로젝트 리스트 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `타인이 포함된 프로젝트 리스트 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`타인이 포함된 프로젝트 리스트 조회 실패: ${error}`);
+      throw new Error(`타인이 포함된 프로젝트 리스트 조회: ${error}`);
+    }
+  }
+};
+
+// 프로젝트 수정 시에 가져올 프로젝트 상세조회
 export const getEditProjectDetails = async (projectId: number): Promise<ProjectDetailResponse> => {
   try {
-    // 아래 2개의 api는 리턴값이 동일함..!
-    // /api/v1/projects/me-involved-projects/{projectId}
-    // /api/v1/projects/summary/detail/{projectId}
+    // 프로젝트 수정 전용 api가 없어서 me-involved 호출
     const response = await ax.get<ProjectDetailResponse>(
       `/api/v1/projects/me-involved-projects/${projectId}`,
+    );
+    console.log('Get Edit Project Details Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `프로젝트 수정 상세 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `프로젝트 수정 상세 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`프로젝트 수정 상세 조회 실패: ${error}`);
+      throw new Error(`프로젝트 수정 상세 조회: ${error}`);
+    }
+  }
+};
+
+// 내가 포함된 프로젝트 상세 조회 (마이페이지에서 접속)
+export const getMyProjectDetails = async (projectId: number): Promise<ProjectDetailResponse> => {
+  try {
+    const response = await ax.get<ProjectDetailResponse>(
+      `/api/v1/projects/me-involved-projects/${projectId}`,
+    );
+    console.log('Get My Project Details Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `내 프로젝트 상세 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `내 프로젝트 상세 조회 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`내 프로젝트 상세 조회 실패: ${error}`);
+      throw new Error(`내 프로젝트 상세 조회 실패: ${error}`);
+    }
+  }
+};
+
+// 타인의 프로젝트 (타인 프로필에서 접속), 검색 결과 프로젝트 상세 조회
+export const getProjectDetails = async (projectId: number): Promise<ProjectDetailResponse> => {
+  try {
+    const response = await ax.get<ProjectDetailResponse>(
+      `/api/v1/projects/summary/detail/${projectId}`,
     );
     console.log('Get Project Details Response:', response.data);
     return response.data;
@@ -135,7 +229,83 @@ export const getEditProjectDetails = async (projectId: number): Promise<ProjectD
       throw new Error(`프로젝트 상세 조회 실패: ${error.response?.data?.message || error.message}`);
     } else {
       console.error(`프로젝트 상세 조회 실패: ${error}`);
-      throw new Error(`프로젝트 상세 조회: ${error}`);
+      throw new Error(`프로젝트 상세 조회 실패: ${error}`);
+    }
+  }
+};
+
+// 특정 프로젝트에서 본인의 익명 처리 여부 설정 (공개/비공개)
+export const updateMyProjectVisibility = async (
+  projectId: number,
+  visibility: boolean,
+): Promise<MyProjectVisibilityResponse> => {
+  try {
+    const response = await ax.put<MyProjectVisibilityResponse>(`/api/v1/projects/visibility`, {
+      projectId,
+      urlVisibility: visibility, // 근데 이거 .. urlVisibility 라고 되어있는데 .. 아 근데 말하기가 싫다..
+    });
+    console.log('Update My Project Visibility Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(
+        `내 프로젝트 공개 여부 수정 실패: ${error.response?.data?.message || error.message}`,
+      );
+      console.error('Full error response:', error.response?.data);
+      throw new Error(
+        `내 프로젝트 공개 여부 수정 실패: ${error.response?.data?.message || error.message}`,
+      );
+    } else {
+      console.error(`내 프로젝트 공개 여부 수정 실패: ${error}`);
+      throw new Error(`내 프로젝트 공개 여부 수정 실패: ${error}`);
+    }
+  }
+};
+
+// 프로젝트 연동하기
+export const linkProject = async (
+  projectId: number,
+  anonymousEmail: string,
+): Promise<ProjectDetailResponse> => {
+  try {
+    const response = await ax.post<ProjectDetailResponse>(
+      `/api/v1/projects/link-project/${projectId}`,
+      {
+        params: { anonymousEmail },
+      },
+    );
+    console.log('Create Project Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프로젝트 등록 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프로젝트 등록 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프로젝트 등록 실패: ${error}`);
+      throw new Error(`프로젝트 등록 실패: ${error}`);
+    }
+  }
+};
+
+// 프로젝트 검색하기
+export const getSearchProjects = async (
+  searchCondition: ProjectSearchRequest,
+): Promise<ProjectSearchResponse> => {
+  try {
+    const response = await ax.get<ProjectSearchResponse>('/api/v1/search/projects', {
+      params: searchCondition,
+    });
+    console.log('Get Search Projects Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프로젝트 검색 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프로젝트 검색 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프로젝트 검색 실패: ${error}`);
+      throw new Error(`프로젝트 검색 실패: ${error}`);
     }
   }
 };

--- a/src/services/api/projectApi.ts
+++ b/src/services/api/projectApi.ts
@@ -11,6 +11,8 @@ import type {
   MyProjectVisibilityResponse,
   ProjectSearchRequest,
   ProjectSearchResponse,
+  MyProjectVisibilityRequest,
+  LinkProjectRequest,
 } from '@/models/project/projectApiModels';
 
 // 프로젝트 등록
@@ -236,13 +238,12 @@ export const getProjectDetails = async (projectId: number): Promise<ProjectDetai
 
 // 특정 프로젝트에서 본인의 익명 처리 여부 설정 (공개/비공개)
 export const updateMyProjectVisibility = async (
-  projectId: number,
-  visibility: boolean,
+  data: MyProjectVisibilityRequest,
 ): Promise<MyProjectVisibilityResponse> => {
   try {
     const response = await ax.put<MyProjectVisibilityResponse>(`/api/v1/projects/visibility`, {
-      projectId,
-      urlVisibility: visibility, // 근데 이거 .. urlVisibility 라고 되어있는데 .. 아 근데 말하기가 싫다..
+      projectId: data.projectId,
+      urlVisibility: data.visibility, // 근데 이거 .. urlVisibility 라고 되어있는데 .. 아 근데 말하기가 싫다..
     });
     console.log('Update My Project Visibility Response:', response.data);
     return response.data;
@@ -263,15 +264,12 @@ export const updateMyProjectVisibility = async (
 };
 
 // 프로젝트 연동하기
-export const linkProject = async (
-  projectId: number,
-  anonymousEmail: string,
-): Promise<ProjectDetailResponse> => {
+export const linkProject = async (data: LinkProjectRequest): Promise<ProjectDetailResponse> => {
   try {
     const response = await ax.post<ProjectDetailResponse>(
-      `/api/v1/projects/link-project/${projectId}`,
+      `/api/v1/projects/link-project/${data.projectId}`,
       {
-        params: { anonymousEmail },
+        params: { anonymousEmail: data.anonymousEmail },
       },
     );
     console.log('Create Project Response:', response.data);


### PR DESCRIPTION
## 💡 ISSUE 번호

#78 

<br/>

## 🔎 작업 내용

- 프로젝트 api에서 사용되는 타입들, axios, query 생성 (프로젝트 검색 service도 추가했습니다.)
- 로그인한 유저와 타 유저가 구분되는 페이지에서 공통으로 쓰이는 컴포넌트에 isFromMyProfile props값을 필수로 수정 (경고가 떠야 안헷갈리더라구요..)

### API 연동 완료
- 프로필 하단 참여한 프로젝트 리스트 (본인, 다른유저 분기처리하여 둘 다 적용)
- 프로필에서 타고 넘어가는 특정 유저 별 프로젝트 상세페이지 (본인, 다른유저 분기처리하여 둘 다 적용)
- 마이프로필에서 프로젝트 별 본인 공개 여부 설정
- 검색 결과 프로젝트 리스트에서 조회하는 프로젝트 상세 페이지, 유저 카드 클릭 시 해당 유저 프로필로 이동


<br/>

## 📢 주의 및 리뷰 요청

- 서버에서 받는 date 의 형식이 타임스탬프와 `YYYY-MM-dd` 형태가 섞여있습니다. 검색 조회 결과로는 타임스탬프 형태로 돌아와서, 타임스탬프 -> `YYYY-MM-dd` 형태로 바꿔주는 유틸함수 하나 추가했습니다.
- project/[projectId]/page.tsx 페이지 내에 컴포넌트를 나눌까 하다가 ..우선 한 곳에 다 넣었습니다.
- 현재 프로젝트 등록/수정 시에 url visibility 값을 입력받지 않아 해당 부분은 추가 예정입니다.

### 백엔드에서 수정해주고 고칠 것들 : #90
- /api/v1/projects/me-involved-projects
프로젝트 별로 본인의 anonyVisibility 값 추가로 필요 (마이페이지에서 목록 조회할 때 토글에 기존 값 넣어야해서 필요함) 

- /api/v1/projects/visibility
body의 `urlVisibility -> visibility`로 변경 필요
=> `projectApi.ts`의 `updateMyProjectVisibility` 도 추후 수정 필요

### 다음에 진행할 것 : #81 

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
