### PR TITLE
Fix/#93 프로필 수정 렌더링 이슈 수정

### DIFF
--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -37,7 +37,9 @@ export default function EditMyPage() {
   }, [user]);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value);
+    if (e.target.value.length <= 10) {
+      setName(e.target.value);
+    }
   };
 
   const handleOpenSelectInterestJobsModal = () => {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,7 +14,7 @@ export default function MyPage() {
           <ProjectRegisterButton text="새 프로젝트 등록하기" className="h-[45px] w-[210px]" />
         </div>
         <h2 className="text-gray-900 body6">프로필</h2>
-        <UserProfile fromMyProfile iconIndex={0} />
+        <UserProfile fromMyProfile />
       </section>
       <section className="relative flex flex-col gap-3">
         <div className="flex items-center justify-between">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,7 +14,7 @@ export default function MyPage() {
           <ProjectRegisterButton text="새 프로젝트 등록하기" className="h-[45px] w-[210px]" />
         </div>
         <h2 className="text-gray-900 body6">프로필</h2>
-        <UserProfile fromMyProfile />
+        <UserProfile fromMyProfile iconIndex={0} />
       </section>
       <section className="relative flex flex-col gap-3">
         <div className="flex items-center justify-between">

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -46,6 +46,7 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
       )}
     </span>
   );
+
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center p-12">
       <div className="flex w-full max-w-[1040px] flex-col gap-10">
@@ -143,7 +144,7 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                 /* member의 명확한 식별자가 없어서 key는 index로 사용 */
                 memberList.map((member, index) => (
                   <li key={index}>
-                    <UserSummaryCard userData={member} variant={member.type} />
+                    <UserSummaryCard userData={member} variant={member.type} iconIndex={index} />
                   </li>
                 ))
               }

--- a/src/components/domain/survey/answerRow/CheckBoxRow.tsx
+++ b/src/components/domain/survey/answerRow/CheckBoxRow.tsx
@@ -5,13 +5,14 @@ interface CheckBoxRowProps {
   name: string;
   member: string;
   register: UseFormRegister<Record<string, unknown>>;
+  iconIndex: number;
 }
 
-export default function CheckBoxRow({ name, member, register }: CheckBoxRowProps) {
+export default function CheckBoxRow({ name, member, register, iconIndex }: CheckBoxRowProps) {
   return (
     <div className="mb-2 flex w-full items-center justify-between rounded-[20px] bg-gray-100 px-4 py-2 md:px-8">
       <div className="flex items-center gap-4">
-        <CirclePlanetIcon className="bg-gray-200" />
+        <CirclePlanetIcon className="bg-gray-200" iconIndex={iconIndex} />
         <span className="mr-4 mobile1">{member}</span>
         <input
           type="checkbox"

--- a/src/components/domain/survey/answerRow/RatingRow.tsx
+++ b/src/components/domain/survey/answerRow/RatingRow.tsx
@@ -7,13 +7,14 @@ interface RatingRowProps {
   name: string;
   member: string;
   register: UseFormRegister<Record<string, unknown>>;
+  iconIndex: number;
 }
 
-export default function RatingRow({ name, member, register }: RatingRowProps) {
+export default function RatingRow({ name, member, register, iconIndex }: RatingRowProps) {
   return (
     <div className="mb-2 flex w-full items-center justify-between rounded-[20px] bg-gray-100 px-4 py-2 md:px-8">
       <div className="flex items-center gap-4">
-        <CirclePlanetIcon className="bg-gray-200" />
+        <CirclePlanetIcon className="bg-gray-200" iconIndex={iconIndex} />
         <span className="mobile1">{member}</span>
       </div>
       <RadioGroup className="flex items-center space-x-4 md:space-x-8 lg:space-x-20">

--- a/src/components/domain/survey/answerRow/TextRow.tsx
+++ b/src/components/domain/survey/answerRow/TextRow.tsx
@@ -6,13 +6,14 @@ interface TextRowProps {
   name: string;
   member: string;
   register: UseFormRegister<Record<string, unknown>>;
+  iconIndex: number;
 }
 
-export default function TextRow({ name, member, register }: TextRowProps) {
+export default function TextRow({ name, member, register, iconIndex }: TextRowProps) {
   return (
     <div className="mb-2 flex w-full rounded-[20px] bg-gray-100 py-2 md:px-8">
       <div className="flex items-center gap-4">
-        <CirclePlanetIcon className="bg-gray-200" />
+        <CirclePlanetIcon className="bg-gray-200" iconIndex={iconIndex} />
         <span className="mr-4 mobile1">{member}</span>
       </div>
       <div className="flex w-[75%] flex-col space-y-3">

--- a/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
+++ b/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
@@ -25,6 +25,7 @@ export default function CheckBoxAnswer({
             name={`question${stepNumber}_${member}`}
             member={member}
             register={register}
+            iconIndex={index}
           />
         ))}
       </div>

--- a/src/components/domain/survey/answerType/RatingAnswer.tsx
+++ b/src/components/domain/survey/answerType/RatingAnswer.tsx
@@ -28,6 +28,7 @@ export default function RatingAnswer({
               name={`question${stepNumber}_${member}`}
               member={member}
               register={register}
+              iconIndex={index}
             />
           ))}
         </div>

--- a/src/components/domain/survey/answerType/TextAnswer.tsx
+++ b/src/components/domain/survey/answerType/TextAnswer.tsx
@@ -41,6 +41,7 @@ export default function TextAnswer({
           name={`question${stepNumber}_${member}`}
           member={member}
           register={register}
+          iconIndex={index}
         />
       ))}
     </SurveyLayout>

--- a/src/components/domain/user/CirclePlanetIcon.tsx
+++ b/src/components/domain/user/CirclePlanetIcon.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { useEffect, useState } from 'react';
 import { PlanetIcons } from '@/assets/icon/planet';
 import { ComponentSpinner } from '@/components/common/spinner';
 
@@ -10,42 +9,23 @@ interface CirclePlanetIconProps {
   iconIndex?: number;
 }
 
-const CirclePlanetIcon = ({ className, iconIndex }: CirclePlanetIconProps) => {
+export default function CirclePlanetIcon({ className, iconIndex }: CirclePlanetIconProps) {
   const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
-  const [randomIndex, setRandomIndex] = useState<number | null>(null);
-
-  // hydration 오류로, 마운트 된 경우에만 아이콘 접근하도록 수정
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-    if (iconIndex === undefined) {
-      setRandomIndex(Math.floor(Math.random() * planetKeys.length));
-    }
-  }, [iconIndex, planetKeys.length]);
-
-  if (!isMounted) {
-    // 로딩 상태 표시
-    return (
-      <div className="h-[56px] w-[56px] flex-center">
-        <ComponentSpinner />
-      </div>
-    );
-  }
-
   const PlanetIcon =
     iconIndex !== undefined
-      ? PlanetIcons[planetKeys[iconIndex]]
-      : randomIndex !== null
-        ? PlanetIcons[planetKeys[randomIndex]]
-        : null;
+      ? PlanetIcons[planetKeys[iconIndex % planetKeys.length]]
+      : PlanetIcons[planetKeys[0]];
 
   return (
     <div
       className={cn('flex h-[56px] w-[56px] items-center justify-center rounded-full', className)}>
-      {PlanetIcon && <PlanetIcon />}
+      {PlanetIcon ? (
+        <PlanetIcon />
+      ) : (
+        <div className="h-[56px] w-[56px] flex-center">
+          <ComponentSpinner />
+        </div>
+      )}
     </div>
   );
-};
-
-export default CirclePlanetIcon;
+}

--- a/src/components/domain/user/CirclePlanetIcon.tsx
+++ b/src/components/domain/user/CirclePlanetIcon.tsx
@@ -2,30 +2,20 @@
 
 import { cn } from '@/lib/utils';
 import { PlanetIcons } from '@/assets/icon/planet';
-import { ComponentSpinner } from '@/components/common/spinner';
 
 interface CirclePlanetIconProps {
   className?: string;
   iconIndex?: number;
 }
 
-export default function CirclePlanetIcon({ className, iconIndex }: CirclePlanetIconProps) {
+export default function CirclePlanetIcon({ className, iconIndex = 0 }: CirclePlanetIconProps) {
   const planetKeys = Object.keys(PlanetIcons) as Array<keyof typeof PlanetIcons>;
-  const PlanetIcon =
-    iconIndex !== undefined
-      ? PlanetIcons[planetKeys[iconIndex % planetKeys.length]]
-      : PlanetIcons[planetKeys[0]];
+  const PlanetIcon = PlanetIcons[planetKeys[iconIndex % planetKeys.length]];
 
   return (
     <div
       className={cn('flex h-[56px] w-[56px] items-center justify-center rounded-full', className)}>
-      {PlanetIcon ? (
-        <PlanetIcon />
-      ) : (
-        <div className="h-[56px] w-[56px] flex-center">
-          <ComponentSpinner />
-        </div>
-      )}
+      {PlanetIcon && <PlanetIcon />}
     </div>
   );
 }

--- a/src/components/domain/user/UserProfile.tsx
+++ b/src/components/domain/user/UserProfile.tsx
@@ -8,9 +8,10 @@ import { PencilLine } from 'lucide-react';
 
 interface UserProfileProps {
   fromMyProfile: boolean;
+  iconIndex: number;
 }
 
-export default function UserProfile({ fromMyProfile }: UserProfileProps) {
+export default function UserProfile({ fromMyProfile, iconIndex }: UserProfileProps) {
   const userData = useUserStore((state) => state.user);
 
   const profileData = [
@@ -28,7 +29,7 @@ export default function UserProfile({ fromMyProfile }: UserProfileProps) {
   return (
     <section className="relative flex w-full">
       <div className="mr-4 flex w-[248px] rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6 flex-col-center">
-        <CirclePlanetIcon className="bg-white" />
+        <CirclePlanetIcon className="bg-white" iconIndex={iconIndex} />
         <span className="mt-2.5 text-white">{userData?.name}</span>
       </div>
       <BorderCard className="flex h-[185px] w-full min-w-0 max-w-[776px] p-8">

--- a/src/components/domain/user/UserProfile.tsx
+++ b/src/components/domain/user/UserProfile.tsx
@@ -8,10 +8,9 @@ import { PencilLine } from 'lucide-react';
 
 interface UserProfileProps {
   fromMyProfile: boolean;
-  iconIndex: number;
 }
 
-export default function UserProfile({ fromMyProfile, iconIndex }: UserProfileProps) {
+export default function UserProfile({ fromMyProfile }: UserProfileProps) {
   const userData = useUserStore((state) => state.user);
 
   const profileData = [
@@ -29,7 +28,7 @@ export default function UserProfile({ fromMyProfile, iconIndex }: UserProfilePro
   return (
     <section className="relative flex w-full">
       <div className="mr-4 flex w-[248px] rounded-[30px] bg-gradient-to-br from-[#1E1B4B] via-[#1E1B4B] to-[#312E81] body6 flex-col-center">
-        <CirclePlanetIcon className="bg-white" iconIndex={iconIndex} />
+        <CirclePlanetIcon className="bg-white" iconIndex={0} />
         <span className="mt-2.5 text-white">{userData?.name}</span>
       </div>
       <BorderCard className="flex h-[185px] w-full min-w-0 max-w-[776px] p-8">

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -16,15 +16,17 @@ import { maskEmail, maskName } from '@/lib/masking';
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/stores/userStore';
 
-interface UserSummaryCard {
+interface UserSummaryCardProps {
   userData: UserSummaryData;
   variant?: UserSummaryCardVariant;
+  iconIndex: number;
 }
 
 export default function UserSummaryCard({
   userData,
   variant = USER_CARD_VARIANT.MEMBER_PUBLIC,
-}: UserSummaryCard) {
+  iconIndex,
+}: UserSummaryCardProps) {
   const router = useRouter();
   const user = useUserStore((state) => state.user);
   const isPublicUser = variant === USER_CARD_VARIANT.MEMBER_PUBLIC;
@@ -47,7 +49,7 @@ export default function UserSummaryCard({
       )}
       onClick={handleOpenUserProfile}>
       <div className="flex items-start space-x-4">
-        <CirclePlanetIcon className="bg-gray-100" />
+        <CirclePlanetIcon className="bg-gray-100" iconIndex={iconIndex} />
         <div className="flex flex-col justify-center">
           <p className="body8">
             {variant === USER_CARD_VARIANT.MEMBER_PRIVATE ? maskName(userData.name) : userData.name}

--- a/src/hooks/queries/useUserService.ts
+++ b/src/hooks/queries/useUserService.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { userProfileDataByUserId, updateProfile } from '@/services/api/userApi';
 import {
   UpdateProfileRequest,
@@ -16,11 +16,13 @@ export const useUserProfileByUserId = (userId: string) => {
     queryKey: ['userProfileByUserId', userId],
     queryFn: () => userProfileDataByUserId(userId),
     retry: false,
+    enabled: !!userId, // userId가 있을 때만 쿼리 실행
   });
 };
 
 // 로그인 한 사용자의 프로필 수정하기
 export const useUpdateProfile = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
   const { user, setUser } = useUserStore();
 
@@ -38,6 +40,11 @@ export const useUpdateProfile = () => {
         skills: requestProfileData?.skills || [],
       };
       setUser(userNewData);
+
+      // 쿼리 무효화
+      if (user?.userId) {
+        queryClient.invalidateQueries({ queryKey: ['userProfileByUserId', user.userId] });
+      }
 
       // 마이 페이지로 이동
       router.push('/mypage');

--- a/src/models/auth/authModels.ts
+++ b/src/models/auth/authModels.ts
@@ -28,7 +28,7 @@ export const SignupSchema = z
     name: z
       .string()
       .min(1, '이름을 입력해주세요.')
-      .max(30, '이름은 최대 30자까지 입력 가능합니다.')
+      .max(10, '이름은 최대 10자까지 입력 가능합니다.')
       .regex(nameRegex, nameRegexMessage),
     email: z
       .string()


### PR DESCRIPTION
## 💡 ISSUE 번호

#93 

<br/>

## 🔎 작업 내용

- `useUpdateProfile` 쿼리 무효화 로직 추가
- `CirclePlanetIcon` 렌더링 로직 변경
- 회원가입 시 이름 최대 글자 30->10글자로 수정
- 프로필 수정에서 이름 10글자 이상 입력하지 못하도록 수정

<br/>

## 📢 주의 및 리뷰 요청

- `retry: false`는 쿼리가 실패했을 때 재시도하지 않도록 설정하는 것이라고 합니다. 하지만 현재 문제는 데이터가 업데이트된 후 페이지가 리렌더링되지 않아서 발생하는 것라서 `useUserProfileByUserId`에서 `retry: false`는 따로 제거하지 않았습니다. 
- 대신 어제 논의한 쿼리 무효화 로직을 추가했고, 정상 동작하는 것 확인했습니다.


https://github.com/user-attachments/assets/b8e4a741-9a2e-450f-907c-ca969afb90fa


- `CirclePlanetIcon`은 프로젝트 등록 step2에서 사용하신 방향으로 수정했습니다.
- 프로필 내 이름이 길면 UI 상으로 깨지는 부분이 여기저기 많이 발생할 것 같아서 혜선 님께 변경 여부 문의드린 상태이며, 마이페이지에서 데스크탑 기준으로 어색하지 않으려면 10자가 적당할 것 같아서 이렇게 설정하였습니다. 
<img width="248" alt="스크린샷 2024-07-25 오전 4 20 31" src="https://github.com/user-attachments/assets/d08086f4-8129-4d08-bcc8-04047e34c466">
<img width="266" alt="스크린샷 2024-07-25 오전 4 20 55" src="https://github.com/user-attachments/assets/a7bf3789-b533-4c75-9eb5-5840e0e3ad01">

- 10자여도 프로필 요약 카드 같은 곳에서는 좀 이슈가 생길 것 같지만, 이 부분은 추후 모아서 작업하면 좋을 것 같습니다.



<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
