### PR TITLE
Feat/#98 프로젝트 등록 시, 이메일 수신 동의 여부 메시지박스 추가

### DIFF
--- a/src/components/common/messgeBox/MessageBox.tsx
+++ b/src/components/common/messgeBox/MessageBox.tsx
@@ -2,15 +2,18 @@
 
 import ModalLayout from '@/components/common/modal/ModalLayout';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import { useModalStore } from '@/stores/modalStore';
 
 // 제목, 버튼 필수
 interface MessageBoxProps {
   title: React.ReactNode;
   titleIcon?: JSX.Element;
-  subTitle?: string; // with Color
+  subTitle?: React.ReactNode; // with Color
   description?: string;
   footer: React.ReactNode;
+  showCloseButton?: boolean;
+  contentClassName?: string;
 }
 
 export default function MessageBox({
@@ -19,6 +22,8 @@ export default function MessageBox({
   subTitle,
   description = '',
   footer,
+  showCloseButton = true,
+  contentClassName = '',
 }: MessageBoxProps) {
   return (
     <div className="shadow-custom-6px">
@@ -31,9 +36,10 @@ export default function MessageBox({
           </div>
         }
         description={description}
-        contentClassName="max-w-[500px] px-[50px]"
+        contentClassName={cn('max-w-[500px] px-[50px]', contentClassName)}
         transparentOverlay={true}
         footer={<div className="mt-5 w-full gap-1 flex-center">{footer}</div>}
+        showCloseButton={showCloseButton}
       />
     </div>
   );

--- a/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
+++ b/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
@@ -10,7 +10,14 @@ import {
 
 import { Form } from '@/components/ui/form';
 
-import { ClipboardCheck, HeartHandshake, LucideFileEdit, Send, UserCheck } from 'lucide-react';
+import {
+  ClipboardCheck,
+  HeartHandshake,
+  LucideFileEdit,
+  MailCheck,
+  Send,
+  UserCheck,
+} from 'lucide-react';
 
 import ModalLayout from '@/components/common/modal/ModalLayout';
 import ProgressBar from '@/components/common/progressBar/ProgressBar';
@@ -23,7 +30,7 @@ import ProjectRegisterFooter from './layout/ProjectRegisterFooter';
 import { PageSpinner } from '@/components/common/spinner';
 import MessageBox from '@/components/common/messgeBox/MessageBox';
 
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
 import { useModalStore } from '@/stores/modalStore';
@@ -121,7 +128,15 @@ export default function ProjectRegisterModal({
       result = await formMethods.trigger(['projectName', 'startDate', 'endDate']);
     } else if (currStep === 1) {
       result = await formMethods.trigger(['members']);
+
+      // Step2일 경우, 이메일 수신 동의 메시지 박스를 띄운다.
+      // 등록이든 수정이든, 이메일이 바뀔 수 있으니 항상 띄우게 함.
+      if (result) {
+        openModal(<EmailConsentConfirmation setCurrStep={setCurrStep} />);
+        return;
+      }
     }
+
     if (result && currStep < MAX_STEP) {
       setCurrStep((prev) => prev + 1);
     }
@@ -242,6 +257,34 @@ const SendSurveyCompleteMessage = () => {
       title={renderTitle()}
       titleIcon={<Send className="stroke-purple-500" />}
       footer={<MessageBox.MessageConfirmButton text="완료" onClick={handleClickComplete} />}
+    />
+  );
+};
+
+const EmailConsentConfirmation = ({
+  setCurrStep,
+}: {
+  setCurrStep: Dispatch<SetStateAction<number>>;
+}) => {
+  const handleEmailConsentConfirm = () => {
+    setCurrStep((prev) => prev + 1);
+  };
+  const handleClickShowTerms = () => {
+    alert('이메일 수신 동의 약관');
+  };
+  return (
+    <MessageBox
+      title={
+        <div>
+          팀원들로부터 이메일 수신에 대한
+          <br /> 동의를 받았음을 확인합니다.
+        </div>
+      }
+      subTitle={<a onClick={handleClickShowTerms}>이메일 수신 이용 약관</a>}
+      titleIcon={<MailCheck className="stroke-purple-500" />}
+      footer={<MessageBox.MessageConfirmButton text="확인" onClick={handleEmailConsentConfirm} />}
+      showCloseButton={false}
+      contentClassName="max-w-[600px]"
     />
   );
 };


### PR DESCRIPTION
## 💡 ISSUE 번호

#98 

<br/>

## 🔎 작업 내용

- Step2에서 넘어갈 때 이메일 수신 동의 여부 메시지박스 확인 버튼 눌러야 Step3로 넘어가게 수정, Step2에 들어오면 이메일을 수정할 수도 있으니까 일단 항상 뜨게함. (나중에 한번만 확인 눌러도 되게하거나... 혜선님과 논의하고 수정할게요!)

### 메시지박스

- 메시지박스 최대 너비가, 이메일 수신 동의 여부 문구를 다 담기에 좀 좁아서, 기존 500px은 유지하면서 className으로 최대 너비 조정하게함
- subTitle은 React.ReactNode로 타입 변경하여 일반 string, 태그 다 담게함 -> 클릭 시 이메일 수신 동의 약관서 띄워야해서 수정

<img width="733" alt="image" src="https://github.com/user-attachments/assets/df89b638-c3a8-4fe0-899c-d49902637f3a">


<br/>

## 📢 주의 및 리뷰 요청

- 내용을 입력해주세요.

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
