### PR TITLE
Feat/#91 프로젝트 수정 시 url visibility 값 추가

### DIFF
--- a/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
+++ b/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
@@ -113,6 +113,7 @@ export default function ProjectRegisterModal({
         },
       ],
       projectUrlLink: defaultData?.projectUrlLink || '',
+      urlVisibility: defaultData?.urlVisibility || false,
       projectDescription: defaultData?.projectDescription || '',
       skills: defaultData?.skills || [],
       categories: defaultData?.categories || [],
@@ -157,7 +158,6 @@ export default function ProjectRegisterModal({
         endDate: formatDateToYYYYMMDDHHmmss(data.endDate || defaultDate),
         memberCount: data.members.length,
       };
-
       // 현재 수정모드인지에 따라 다른 mutate 실행
       if (isEdit && projectId) {
         updateMutation.mutate({ projectId, data: mutationData });
@@ -189,7 +189,7 @@ export default function ProjectRegisterModal({
             <form>
               {currStep === 0 && <Step1 />}
               {currStep === 1 && <Step2 />}
-              {currStep === 2 && <Step3 />}
+              {currStep === 2 && <Step3 isEdit={isEdit} />}
             </form>
           </FormProvider>
         </Form>

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -157,6 +157,7 @@ export const useGetProjectDetails = (successCallback: (projectDetailData: Projec
         endDate: convertStringToDate(detailData.endDate),
         members: detailData.members,
         projectUrlLink: detailData.projectUrlLink,
+        urlVisibility: detailData.urlVisibility,
         projectDescription: detailData.projectDescription,
         skills: detailData.skills,
         categories: detailData.categories,

--- a/src/models/project/projectModels.ts
+++ b/src/models/project/projectModels.ts
@@ -31,6 +31,7 @@ export const ProjectFormSchema = z.object({
   }),
   members: z.array(ProjectMemberSchema),
   projectUrlLink: z.string(),
+  urlVisibility: z.boolean(),
   projectDescription: z.string(),
   skills: z.array(z.string()),
   categories: z.array(z.string()),


### PR DESCRIPTION
## 💡 ISSUE 번호

#91 

<br/>

## 🔎 작업 내용

- 프로젝트 url 링크 공개/비공개 여부 필드 추가
- 프로젝트 등록시에는 안뜨고, 수정 시에만 뜨도록 설정 (기획이 이렇게 되어있습니다! 그리고 등록 쪽에도 값 반영하려면 api 가 바뀌어야해서 .. 그냥 처음대로 프로젝트 수정 시에만 뜨게 했습니다)

https://github.com/user-attachments/assets/4a5375a1-f389-412b-821d-eb862c714d80


<br/>

## 📢 주의 및 리뷰 요청

- 현재 수정 api 호출 시, urlVisibility 값은 잘 전송되고 응답도 잘 받는데,, 프로젝트를 상세 조회하면 값이 반영이 안되고 있어서 백엔드분께 문의 드린 상태입니다. 참고 부탁드립니다!

<img width="919" alt="image" src="https://github.com/user-attachments/assets/8725ab9e-1db8-411b-9aeb-530bdb3373af">

- 20240728 12:30 분 기준 api 수정되어 url visibility 저장/조회 가능합니다!

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
