### PR TITLE
Feat/#116 prism 분석 시작 api 연동

### DIFF
--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -1,12 +1,19 @@
 import { Button } from '@/components/ui/button';
+import { useUpdatePRismEvaluation } from '@/hooks/queries/usePRismService';
 
 interface ProjectEvaluationButtonProps {
   projectId: number;
 }
 
 export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
+  const handlePRismUpdateSuccess = () => {
+    // 나중에 메시지박스 추가? 피그마에 내용 없어서 alert 처리함
+    alert('PRism 분석이 갱신되었어요!');
+  };
+  const updatePRismMutation = useUpdatePRismEvaluation(handlePRismUpdateSuccess);
+
   const handleStartEvaluation = () => {
-    alert(`${projectId}번 프로젝트 프리즘 분석하기 api 호출, 후처리`);
+    updatePRismMutation.mutate(projectId);
   };
 
   return (

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -129,6 +129,7 @@ const RightSection = ({
       )}
       {variant === PROJECT_CARD_VARIANT.ADMIN && (
         <>
+          {/* 프로젝트 삭제/수정 버튼 */}
           <ProjectEditDeleteButton projectId={projectId} />
           <footer className="flex flex-col items-end gap-1">
             <p className="flex items-center gap-2">
@@ -138,7 +139,9 @@ const RightSection = ({
               </strong>
             </p>
             <div className="flex gap-2">
+              {/* 평가지 보내기 버튼 */}
               <ProjectSendEvaluationLink projectId={projectId} />
+              {/* 프리즘 분석 갱신하기 버튼 */}
               <ProjectEvaluationButton projectId={projectId} />
             </div>
           </footer>

--- a/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
+++ b/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
@@ -86,7 +86,6 @@ export default function ProjectLinkModal({ projectId }: ProjectLinkModalProps) {
 
   const handleLinkProjectSuccess = () => {
     // 연동에 성공하면, 모달을 닫으며 연동 완료 메시지창 띄우기
-    alert('연동 성공');
     closeModal();
     setTimeout(() => {
       openModal(<LinkCompleteMessage />);

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -32,7 +32,7 @@ interface SurveyPageProps {
 }
 
 export default function SurveyPage({ surveyData }: SurveyPageProps) {
-  const [current, setCurrent] = useState<number>(1);
+  const [currentStep, setCurrentStep] = useState<number>(1);
   const [api, setApi] = useState<CarouselApi | null>(null);
   const [showIntroduction, setShowIntroduction] = useState<boolean>(true);
   const [showSubmitMessageBox, setShowSubmitMessageBox] = useState<boolean>(false);
@@ -43,7 +43,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
     defaultValues: {
       responses: surveyQuestions.map((question) => ({
         questionOrder: question.id.toString(),
-        questionType: question.type as 'singleChoice' | 'multipleChoiceMember' | 'shortAnswer',
+        questionType: question.type,
         questionCategory: question.category,
         responseDetails: surveyData.data.revieweeEmails.map((email) => ({
           revieweeEmail: email,
@@ -60,10 +60,10 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   useEffect(() => {
     if (!api) return;
 
-    setCurrent(api.selectedScrollSnap() + 1);
+    setCurrentStep(api.selectedScrollSnap() + 1);
 
     api.on('select', () => {
-      setCurrent(api.selectedScrollSnap() + 1);
+      setCurrentStep(api.selectedScrollSnap() + 1);
     });
   }, [api]);
 
@@ -124,7 +124,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
                   return (
                     <CarouselItem key={index}>
                       <StepComponent
-                        currentStep={current}
+                        currentStep={currentStep}
                         totalSteps={steps.length}
                         question={step.question}
                         stepNumber={step.stepNumber}
@@ -138,7 +138,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
           </FormProvider>
           <div className="flex-center">
             <CarouselPrevious className="h-10 w-10" />
-            {current === steps.length ? (
+            {currentStep === steps.length ? (
               <Button
                 type="button"
                 onClick={() => methods.handleSubmit(onSubmit)()}

--- a/src/hooks/queries/usePRismService.ts
+++ b/src/hooks/queries/usePRismService.ts
@@ -1,10 +1,14 @@
 import { AxiosError } from 'axios';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import type { PRismReportResponse } from '@/models/prism/prismApiModels';
+import type {
+  PRismEvaluationUpdateResponse,
+  PRismReportResponse,
+} from '@/models/prism/prismApiModels';
 import {
   getSingleProjectUserAnalysis,
   getUserOverallProjectAnalysis,
+  updatePrismEvaluation,
 } from '@/services/api/prismApi';
 
 // 특정 프로젝트의 특정 유저에 대한 프리즘 분석 지표 가져오기
@@ -22,5 +26,33 @@ export const useUserOverallProjectAnalysis = (userId: string) => {
     queryKey: ['getUserOverallProjectAnalysis', userId],
     queryFn: () => getUserOverallProjectAnalysis(userId),
     enabled: !!userId, // userId가 없는 경우엔 쿼리 미실행
+  });
+};
+
+// 프리즘 평가 갱신하기
+export const useUpdatePRismEvaluation = (successCallback: () => void) => {
+  return useMutation<PRismEvaluationUpdateResponse, AxiosError, number>({
+    mutationFn: updatePrismEvaluation,
+    onSuccess: (response) => {
+      console.log(response);
+      if (successCallback) successCallback();
+    },
+    onError: (error) => {
+      // 추후 케이스 나눠서 메시징 처리 예정
+      // 1번. 평가 갱신할 권한이 없을 경우(project owner가 아닐경우)
+      // code: PeerReviewCode_400_3,
+      // reason: 평가 갱신을 할 권한이 없습니다.
+
+      // // 2번. ai등 평가 결과를 갱신에 실패할 경우
+      // code: PeerReviewCode_400_4,
+      // reason: 평가 갱신에 실패했습니다.
+
+      // // 3번. 평가를 한 사람이 더이상 없는데 갱신을 할 경우
+      // code: PeerReviewCode_400_5,
+      // reason: 이미 평가 갱신이 완료되었습니다
+
+      alert('PRism 분석 갱신에 실패했습니다.');
+      console.log(error);
+    },
   });
 };

--- a/src/models/prism/prismApiModels.ts
+++ b/src/models/prism/prismApiModels.ts
@@ -19,3 +19,9 @@ export interface PRismReportResponse {
     isEvaluationEmpty?: boolean;
   };
 }
+
+export interface PRismEvaluationUpdateResponse {
+  success: boolean;
+  status: number;
+  data: null;
+}

--- a/src/services/api/prismApi.ts
+++ b/src/services/api/prismApi.ts
@@ -1,7 +1,10 @@
 import { ax } from '../axios';
 import axios from 'axios';
 
-import { PRismReportResponse } from '@/models/prism/prismApiModels';
+import type {
+  PRismReportResponse,
+  PRismEvaluationUpdateResponse,
+} from '@/models/prism/prismApiModels';
 
 // 특정 프로젝트의 특정 유저에 대한 프리즘 분석
 export const getSingleProjectUserAnalysis = async (
@@ -100,6 +103,28 @@ export const getUserOverallProjectAnalysis = async (
     } else {
       console.error(`특정 유저의 전체 프로젝트 종합 프리즘 분석 실패: ${error}`);
       throw new Error(`특정 유저의 전체 프로젝트 종합 프리즘 분석 실패: ${error}`);
+    }
+  }
+};
+
+// 프리즘 평가 갱신하기
+export const updatePrismEvaluation = async (
+  projectId: number,
+): Promise<PRismEvaluationUpdateResponse> => {
+  try {
+    const response = await ax.post<PRismEvaluationUpdateResponse>(
+      `/api/v1/peer-reviews/projects/${projectId}/prism`,
+    );
+    console.log('Update Prism Evaluation Response:', response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.error(`프리즘 분석 갱신 실패: ${error.response?.data?.message || error.message}`);
+      console.error('Full error response:', error.response?.data);
+      throw new Error(`프리즘 분석 갱신 실패: ${error.response?.data?.message || error.message}`);
+    } else {
+      console.error(`프리즘 분석 갱신 실패: ${error}`);
+      throw new Error(`프리즘 분석 갱신 실패: ${error}`);
     }
   }
 };


### PR DESCRIPTION
## 💡 ISSUE 번호

#116 

<br/>

## 🔎 작업 내용

- 프리즘 분석 데이터 분석하기 버튼에 분석 갱신 api 호출 연동
- 평가지 current -> currentStep으로 변경
- 프로젝트 연동 성공 시 alert('연동성공') 삭제

<br/>

## 📢 주의 및 리뷰 요청

- 내용을 입력해주세요.

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
