### PR TITLE
Feat/#119 프로젝트 분석 리포트에 유저 이름 표시되게 수정

### DIFF
--- a/src/components/common/chart/PRismChart.tsx
+++ b/src/components/common/chart/PRismChart.tsx
@@ -14,7 +14,7 @@ import {
 
 interface PRismChartComponentProps {
   data: PRismEvaluation[];
-  name?: string; // 지표에 표시될 사용자 이름
+  userName?: string; // 지표에 표시될 사용자 이름
   hideAxis?: boolean;
   fontSize?: number;
   startColor?: string;
@@ -23,7 +23,7 @@ interface PRismChartComponentProps {
 
 export default function PRismChart({
   data,
-  name = '평가대상이름', // 평가 지표의 대상 이름, 툴팁에 표시될 때 사용
+  userName = '', // 평가 지표의 대상 이름, 툴팁에 표시될 때 사용
   hideAxis = false,
   fontSize = 14,
   startColor = tailwindColors.purple[500],
@@ -55,7 +55,7 @@ export default function PRismChart({
         <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
         <PolarRadiusAxis domain={[0, 100]} axisLine={false} tick={false} />
         <Radar
-          name={name}
+          name={userName}
           dataKey="percent"
           stroke={tailwindColors.purple[500]}
           strokeWidth={1.18}

--- a/src/components/domain/prism/PRismAndRadialReport.tsx
+++ b/src/components/domain/prism/PRismAndRadialReport.tsx
@@ -11,6 +11,7 @@ import ReportBlur from './report/ReportBlur';
 import type { PRismEvaluation } from '@/models/prism/prismModels';
 import { useUserStore } from '@/stores/userStore';
 import { useUserOverallProjectAnalysis } from '@/hooks/queries/usePRismService';
+import { useUserProfileByUserId } from '@/hooks/queries/useUserService';
 
 interface PRismAndRadialReportProps {
   reportedUserId?: string;
@@ -30,6 +31,8 @@ export default function PRismAndRadialReport({
   // fromMyProfile = false : 타인 유저가 속한 전체 프로젝트의 종합 분석
   const loginUser = useUserStore((state) => state.user);
   const targetUserId = fromMyProfile ? loginUser?.userId : reportedUserId;
+
+  const { data: userData } = useUserProfileByUserId(targetUserId || '');
 
   const { data, isLoading, isError } = useUserOverallProjectAnalysis(targetUserId || '');
   console.log(data);
@@ -83,7 +86,7 @@ export default function PRismAndRadialReport({
       <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
         <div className="text-indigo-800 body6">{fromMyProfile && '나의'} PRism</div>
         <div className="h-full w-full">
-          <PRismChart data={prismChartData} />
+          <PRismChart userName={userData?.data.username} data={prismChartData} />
         </div>
       </div>
       <div className="flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] bg-gray-50 px-9 py-3">

--- a/src/components/domain/prism/PRismAndRadialReport.tsx
+++ b/src/components/domain/prism/PRismAndRadialReport.tsx
@@ -45,30 +45,30 @@ export default function PRismAndRadialReport({
       const userPRismChartData: PRismEvaluation[] = [
         {
           evaluation: 'COMMUNICATION',
-          percent: reportData.prismData.communication,
+          percent: (reportData.prismData.communication / 5) * 100,
         },
         {
           evaluation: 'PROACTIVITY',
-          percent: reportData.prismData.proactivity,
+          percent: (reportData.prismData.proactivity / 5) * 100,
         },
         {
           evaluation: 'PROBLEM_SOLVING',
-          percent: reportData.prismData.problemSolving,
+          percent: (reportData.prismData.problemSolving / 5) * 100,
         },
         {
           evaluation: 'RESPONSIBILITY',
-          percent: reportData.prismData.responsibility,
+          percent: (reportData.prismData.responsibility / 5) * 100,
         },
         {
           evaluation: 'COOPERATION',
-          percent: reportData.prismData.cooperation,
+          percent: (reportData.prismData.cooperation / 5) * 100,
         },
       ];
       const userRadialChartData: RadialChartData = {
         radialChartData: {
-          LEADERSHIP: reportData.radialData.leadership,
-          RELIABILITY: reportData.radialData.reliability,
-          TEAMWORK: reportData.radialData.teamwork,
+          LEADERSHIP: (reportData.radialData.leadership / 5) * 100,
+          RELIABILITY: (reportData.radialData.reliability / 5) * 100,
+          TEAMWORK: (reportData.radialData.teamwork / 5) * 100,
         },
         keyword: reportData.radialData.keywords,
         evaluation: reportData.radialData.evaluation,

--- a/src/components/domain/prism/PRismChartExplanationReport.tsx
+++ b/src/components/domain/prism/PRismChartExplanationReport.tsx
@@ -45,23 +45,23 @@ export default function PRismChartExplanationReport({
       const userPRismChartData: PRismEvaluation[] = [
         {
           evaluation: 'COMMUNICATION',
-          percent: reportData.prismData.communication,
+          percent: (reportData.prismData.communication / 5) * 100,
         },
         {
           evaluation: 'PROACTIVITY',
-          percent: reportData.prismData.proactivity,
+          percent: (reportData.prismData.proactivity / 5) * 100,
         },
         {
           evaluation: 'PROBLEM_SOLVING',
-          percent: reportData.prismData.problemSolving,
+          percent: (reportData.prismData.problemSolving / 5) * 100,
         },
         {
           evaluation: 'RESPONSIBILITY',
-          percent: reportData.prismData.responsibility,
+          percent: (reportData.prismData.responsibility / 5) * 100,
         },
         {
           evaluation: 'COOPERATION',
-          percent: reportData.prismData.cooperation,
+          percent: (reportData.prismData.cooperation / 5) * 100,
         },
       ];
       setPRismChartData(userPRismChartData);

--- a/src/components/domain/prism/PRismChartExplanationReport.tsx
+++ b/src/components/domain/prism/PRismChartExplanationReport.tsx
@@ -9,6 +9,7 @@ import PRismExplanation from './report/PRismExplanation';
 import type { PRismEvaluation } from '@/models/prism/prismModels';
 import { useUserStore } from '@/stores/userStore';
 import { useSingleProjectUserAnalysis } from '@/hooks/queries/usePRismService';
+import { useUserProfileByUserId } from '@/hooks/queries/useUserService';
 
 // 유저 -> 프로젝트 상세 조회 시 나타나는 것.
 
@@ -29,6 +30,10 @@ export default function PRismChartExplanationReport({
   const loginUser = useUserStore((state) => state.user);
   const targetUserId = fromMyProfile ? loginUser?.userId : reportedUserId;
 
+  // 조회 유저 데이터 가져오기
+  const { data: userData } = useUserProfileByUserId(targetUserId || '');
+
+  // 조회 유저의 프리즘 데이터 가져오기
   const { data, isLoading, isError } = useSingleProjectUserAnalysis(targetUserId || '', projectId);
   console.log(data);
 
@@ -70,11 +75,11 @@ export default function PRismChartExplanationReport({
       )}
       <div className="flex h-[330px] max-w-[330px] flex-col items-center gap-5 px-9 py-3">
         <div className="h-full w-full">
-          <PRismChart data={prismChartData} />
+          <PRismChart userName={userData?.data.username} data={prismChartData} />
         </div>
       </div>
       <div className="rounded-[30px]px-9 flex min-h-[330px] max-w-[560px] gap-3 py-3 flex-col-center">
-        <PRismExplanation userName="김이름" data={prismChartData} />
+        <PRismExplanation userName={userData?.data.username} data={prismChartData} />
       </div>
     </BorderCard>
   );

--- a/src/components/domain/prism/RadialChartReport.tsx
+++ b/src/components/domain/prism/RadialChartReport.tsx
@@ -41,9 +41,9 @@ export default function RadialChartReport({
     if (reportData && !isEmpty) {
       const userRadialChartData: RadialChartData = {
         radialChartData: {
-          LEADERSHIP: reportData.radialData.leadership,
-          RELIABILITY: reportData.radialData.reliability,
-          TEAMWORK: reportData.radialData.teamwork,
+          LEADERSHIP: (reportData.radialData.leadership / 5) * 100,
+          RELIABILITY: (reportData.radialData.reliability / 5) * 100,
+          TEAMWORK: (reportData.radialData.teamwork / 5) * 100,
         },
         keyword: reportData.radialData.keywords,
         evaluation: reportData.radialData.evaluation,

--- a/src/components/domain/prism/report/PRismExplanation.tsx
+++ b/src/components/domain/prism/report/PRismExplanation.tsx
@@ -6,11 +6,11 @@ import {
 import { ICONS } from '@/components/common/chart/PRismChart';
 
 interface PRismExplanationProps {
-  userName: string;
+  userName?: string;
   data: PRismEvaluation[];
 }
 
-export default function PRismExplanation({ userName, data }: PRismExplanationProps) {
+export default function PRismExplanation({ data, userName = '' }: PRismExplanationProps) {
   const { highestEvaluations, lowestEvaluations } = findExtremeEvaluations(data);
 
   const getColorForEvaluation = (evaluation: PRismEvaluationType) => {
@@ -39,14 +39,16 @@ export default function PRismExplanation({ userName, data }: PRismExplanationPro
       </div>
       <div className="flex flex-col justify-center gap-4 text-gray-800 display5">
         <p>
-          {userName}님의 <span className="text-info-500 mobile2">가장 높은 지표</span>는
+          {userName && `${userName}님의`}
+          <span className="text-info-500 mobile2">가장 높은 지표</span>는
           <span className="mx-2 text-info-500 display6">
             {highestEvaluations.map((evaluation) => PRISM_EVALUATION_LABELS[evaluation]).join(', ')}
           </span>
           입니다.
         </p>
         <p>
-          {userName}님의 <span className="text-purple-500 mobile2">가장 낮은 지표</span>는
+          {userName && `${userName}님의`}
+          <span className="text-purple-500 mobile2">가장 낮은 지표</span>는
           <span className="mx-2 text-purple-500 display6">
             {lowestEvaluations.map((evaluation) => PRISM_EVALUATION_LABELS[evaluation]).join(', ')}
           </span>


### PR DESCRIPTION
## 💡 ISSUE 번호

#119 

<br/>

## 🔎 작업 내용

- 작업 완료한 내역을 작성해주세요.

<br/>

## 📢 주의 및 리뷰 요청

- `PRismChartExplanationReport.tsx` 에 '김이름' 으로 하드코딩 되어있던 것을 조회하려는 유저 이름으로 수정했습니다.
- 원래 서버에서 백분율로 주기로 했는데, 프론트에서 처리하는 것으로 변경되었습니다. 우선 5로 나누고 100으로 곱하는건데 나중에 함수 하나 빼서 공통으로 계산해보도록 하겠습니다.


<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
