### PR TITLE
Feat/#114 평가지 유효성 검사 추가

### DIFF
--- a/src/components/common/input/CustomRadioButton.tsx
+++ b/src/components/common/input/CustomRadioButton.tsx
@@ -2,17 +2,18 @@ import { useFormContext, type UseFormRegister } from 'react-hook-form';
 
 interface CustomRadioButtonProps {
   name: string;
-  value: string;
+  value: number;
   register: UseFormRegister<Record<string, unknown>>;
 }
 
 export default function CustomRadioButton({ name, value, register }: CustomRadioButtonProps) {
   const { watch } = useFormContext();
-  const isSelected = watch(name) === value;
+  const isSelected = watch(name) === value.toString();
 
   return (
     <label className="relative flex cursor-pointer items-center space-x-4">
-      <input type="radio" {...register(name)} value={value} className="hidden" />
+      <input type="radio" {...register(name)} value={value.toString()} className="hidden" />{' '}
+      {/* value를 문자열로 변환하여 전달 */}
       <div className="relative flex h-6 w-6 items-center justify-center">
         <div
           className={`absolute h-full w-full rounded-full border-2 ${

--- a/src/components/common/input/CustomRadioButton.tsx
+++ b/src/components/common/input/CustomRadioButton.tsx
@@ -12,7 +12,7 @@ export default function CustomRadioButton({ name, value, register }: CustomRadio
 
   return (
     <label className="relative flex cursor-pointer items-center space-x-4">
-      <input type="radio" {...register(name)} value={value.toString()} className="hidden" />{' '}
+      <input type="radio" {...register(name)} value={value.toString()} className="hidden" />
       {/* value를 문자열로 변환하여 전달 */}
       <div className="relative flex h-6 w-6 items-center justify-center">
         <div

--- a/src/components/common/input/CustomRadioButton.tsx
+++ b/src/components/common/input/CustomRadioButton.tsx
@@ -2,18 +2,17 @@ import { useFormContext, type UseFormRegister } from 'react-hook-form';
 
 interface CustomRadioButtonProps {
   name: string;
-  value: number;
+  value: string;
   register: UseFormRegister<Record<string, unknown>>;
 }
 
 export default function CustomRadioButton({ name, value, register }: CustomRadioButtonProps) {
   const { watch } = useFormContext();
-  const isSelected = watch(name) === value.toString();
+  const isSelected = watch(name) === value;
 
   return (
     <label className="relative flex cursor-pointer items-center space-x-4">
-      <input type="radio" {...register(name)} value={value.toString()} className="hidden" />
-      {/* value를 문자열로 변환하여 전달 */}
+      <input type="radio" {...register(name)} value={value} className="hidden" />
       <div className="relative flex h-6 w-6 items-center justify-center">
         <div
           className={`absolute h-full w-full rounded-full border-2 ${

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -48,6 +48,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
         responseDetails:
           surveyData?.data?.revieweeInfoList?.map((info) => ({
             revieweeEmail: info.revieweeEmail,
+            revieweeName: info.revieweeName,
             response: {},
           })) ?? [],
       })),
@@ -56,7 +57,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
 
   useEffect(() => {
     if (surveyData?.data?.revieweeInfoList) {
-      setTeamMembers(surveyData.data.revieweeInfoList.map((info) => info.revieweeEmail));
+      setTeamMembers(surveyData.data.revieweeInfoList.map((info) => info.revieweeName));
     }
   }, [surveyData]);
 

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -43,7 +43,6 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   const [teamMembers, setTeamMembers] = useState<string[]>([]);
 
   const methods = useForm<SurveyFormValues>({
-    mode: 'onChange',
     defaultValues: {
       reviewerEmail: surveyData?.data?.reviewerEmail ?? '',
       responses: surveyQuestions.map((question) => ({

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -45,16 +45,19 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
         questionOrder: question.id.toString(),
         questionType: question.type,
         questionCategory: question.category,
-        responseDetails: surveyData.data.revieweeEmails.map((email) => ({
-          revieweeEmail: email,
-          response: {},
-        })),
+        responseDetails:
+          surveyData?.data?.revieweeInfoList?.map((info) => ({
+            revieweeEmail: info.revieweeEmail,
+            response: {},
+          })) ?? [],
       })),
     },
   });
 
   useEffect(() => {
-    setTeamMembers(surveyData.data.revieweeEmails);
+    if (surveyData?.data?.revieweeInfoList) {
+      setTeamMembers(surveyData.data.revieweeInfoList.map((info) => info.revieweeEmail));
+    }
   }, [surveyData]);
 
   useEffect(() => {

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import Link from 'next/link';
+import { z } from 'zod';
 import { useState, useEffect } from 'react';
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 import { useSubmitSurvey } from '@/hooks/queries/useSurveyService';
-import { SurveyStep, SURVEY_QUESTION_TYPE } from '@/models/survey/surveyModels';
 import {
-  SurveyLinkResponse,
-  SubmitSurveyRequest,
+  SurveyStep,
   SurveyFormValues,
-} from '@/models/survey/surveyApiModels';
+  surveyFormSchema,
+  SURVEY_QUESTION_TYPE,
+} from '@/models/survey/surveyModels';
+import { SurveyLinkResponse, SubmitSurveyRequest } from '@/models/survey/surveyApiModels';
 import { surveyQuestions } from '@/lib/surveyQuestions';
 import SurveyIntroduction from '@/components/domain/survey/SurveyIntroduction';
 import RatingAnswer from '@/components/domain/survey/answerType/RatingAnswer';
@@ -25,7 +27,7 @@ import {
   type CarouselApi,
 } from '@/components/ui/carousel';
 import { Button } from '@/components/ui/button';
-import { MailOpen, Sparkles } from 'lucide-react';
+import { MailOpen, Sparkles, AlertTriangle } from 'lucide-react';
 
 interface SurveyPageProps {
   surveyData: SurveyLinkResponse;
@@ -37,10 +39,13 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   const [showIntroduction, setShowIntroduction] = useState<boolean>(true);
   const [showSubmitMessageBox, setShowSubmitMessageBox] = useState<boolean>(false);
   const [showCompletionMessageBox, setShowCompletionMessageBox] = useState<boolean>(false);
+  const [showErrorMessageBox, setShowErrorMessageBox] = useState<boolean>(false);
   const [teamMembers, setTeamMembers] = useState<string[]>([]);
 
   const methods = useForm<SurveyFormValues>({
+    mode: 'onChange',
     defaultValues: {
+      reviewerEmail: surveyData?.data?.reviewerEmail ?? '',
       responses: surveyQuestions.map((question) => ({
         questionOrder: question.id.toString(),
         questionType: question.type,
@@ -48,7 +53,6 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
         responseDetails:
           surveyData?.data?.revieweeInfoList?.map((info) => ({
             revieweeEmail: info.revieweeEmail,
-            revieweeName: info.revieweeName,
             response: {},
           })) ?? [],
       })),
@@ -93,7 +97,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   });
 
   const onSubmit: SubmitHandler<SurveyFormValues> = (data) => {
-    console.log(data);
+    console.log('Submitted data:', data);
     setShowSubmitMessageBox(true);
   };
 
@@ -112,6 +116,35 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
       projectId: parseInt(surveyData.data.projectId, 10),
       data: submitData,
     });
+  };
+
+  const handleValidationAndSubmit = async () => {
+    const formData = methods.getValues();
+
+    // 유효성 검사 추가: 모든 질문에 응답이 있는지 확인
+    const allResponsesFilled = formData.responses.every((response) =>
+      response.responseDetails.every((detail) => {
+        const responseValues = Object.values(detail.response);
+        return (
+          responseValues.length > 0 &&
+          responseValues.every((value) => value !== undefined && value !== null && value !== '')
+        );
+      }),
+    );
+
+    if (!allResponsesFilled) {
+      setShowErrorMessageBox(true);
+      return;
+    }
+    try {
+      const validatedData = surveyFormSchema.parse(formData);
+      onSubmit(validatedData);
+    } catch (error: unknown) {
+      if (error instanceof z.ZodError) {
+        console.error('Validation failed:', error.errors);
+      }
+      setShowErrorMessageBox(true);
+    }
   };
 
   return (
@@ -145,7 +178,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
             {currentStep === steps.length ? (
               <Button
                 type="button"
-                onClick={() => methods.handleSubmit(onSubmit)()}
+                onClick={handleValidationAndSubmit}
                 className="-mt-9 h-[50px] w-[100px] cursor-pointer body8">
                 등록하기
               </Button>
@@ -191,10 +224,24 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
           description="팀원들의 평가 참여도가 높을수록 분석 결과가 정확해요."
           titleIcon={<Sparkles className="h-6 w-6 stroke-purple-600" />}
           footer={
-            // NOTE: 임시로 마이페이지로 보내줌
             <Link href="/mypage">
               <MessageBox.MessageConfirmButton text="내 평가 결과 보러가기" isPrimary={true} />
             </Link>
+          }
+        />
+      )}
+
+      {showErrorMessageBox && (
+        <MessageBox
+          title={<div>모든 항목을 작성해주세요.</div>}
+          description="누락된 응답이 있습니다. 모든 질문에 답변해주세요."
+          titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
+          footer={
+            <MessageBox.MessageConfirmButton
+              text="확인"
+              onClick={() => setShowErrorMessageBox(false)}
+              isPrimary={true}
+            />
           }
         />
       )}

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -116,22 +116,6 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   const handleValidationAndSubmit = async () => {
     const formData = methods.getValues();
 
-    // 유효성 검사 추가: 모든 질문에 응답이 있는지 확인
-    const allResponsesFilled = formData.responses.every((response) =>
-      response.responseDetails.every((detail) => {
-        const responseValues = Object.values(detail.response);
-        return (
-          responseValues.length > 0 &&
-          responseValues.every((value) => value !== undefined && value !== null && value !== '')
-        );
-      }),
-    );
-
-    if (!allResponsesFilled) {
-      openModal(<ErrorMessage />);
-      return;
-    }
-
     try {
       const validatedData = surveyFormSchema.parse(formData);
       onSubmit(validatedData);

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -147,70 +147,6 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
     openModal(<SubmitSurveyMessage handleClickSubmit={handleClickSubmit} />);
   };
 
-  // 평가 제출 메시지창
-  const SubmitSurveyMessage = ({ handleClickSubmit }: { handleClickSubmit: () => void }) => {
-    const { closeModal } = useModalStore();
-
-    return (
-      <MessageBox
-        title={<div>평가를 제출할까요?</div>}
-        titleIcon={<MailOpen className="h-6 w-6 stroke-purple-600" />}
-        footer={
-          <>
-            <MessageBox.MessageConfirmButton
-              text="이전으로"
-              onClick={closeModal}
-              isPrimary={false}
-            />
-            <MessageBox.MessageConfirmButton
-              text="제출하기"
-              onClick={handleClickSubmit}
-              isPrimary
-            />
-          </>
-        }
-      />
-    );
-  };
-
-  // 평가 완료 메시지창
-  const CompletionMessage = () => {
-    return (
-      <MessageBox
-        title={
-          <div className="flex-col-center">
-            <div>이제 팀원들이 평가한 내 협업 능력을 분석한</div>
-            <div className="flex items-center">
-              나의{'\u00A0'}
-              <span className="text-purple-500">PRism</span> 을 볼 수 있어요!
-            </div>
-          </div>
-        }
-        description="팀원들의 평가 참여도가 높을수록 분석 결과가 정확해요."
-        titleIcon={<Sparkles className="h-6 w-6 stroke-purple-600" />}
-        footer={
-          <Link href="/mypage">
-            <MessageBox.MessageConfirmButton text="내 평가 결과 보러가기" isPrimary={true} />
-          </Link>
-        }
-      />
-    );
-  };
-
-  // 오류 메시지창(유효성 검사)
-  const ErrorMessage = () => {
-    const { closeModal } = useModalStore();
-
-    return (
-      <MessageBox
-        title={<div>모든 항목을 작성해주세요.</div>}
-        description="누락된 응답이 있습니다. 모든 질문에 답변해주세요."
-        titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
-        footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
-      />
-    );
-  };
-
   return (
     <div className="container min-h-screen w-full max-w-[1040px] p-4 flex-col-center">
       {showIntroduction ? (
@@ -255,3 +191,59 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
     </div>
   );
 }
+
+// 평가 제출 메시지창
+const SubmitSurveyMessage = ({ handleClickSubmit }: { handleClickSubmit: () => void }) => {
+  const { closeModal } = useModalStore();
+
+  return (
+    <MessageBox
+      title={<div>평가를 제출할까요?</div>}
+      titleIcon={<MailOpen className="h-6 w-6 stroke-purple-600" />}
+      footer={
+        <>
+          <MessageBox.MessageConfirmButton text="이전으로" onClick={closeModal} isPrimary={false} />
+          <MessageBox.MessageConfirmButton text="제출하기" onClick={handleClickSubmit} isPrimary />
+        </>
+      }
+    />
+  );
+};
+
+// 평가 완료 메시지창
+const CompletionMessage = () => {
+  return (
+    <MessageBox
+      title={
+        <div className="flex-col-center">
+          <div>이제 팀원들이 평가한 내 협업 능력을 분석한</div>
+          <div className="flex items-center">
+            나의{'\u00A0'}
+            <span className="text-purple-500">PRism</span> 을 볼 수 있어요!
+          </div>
+        </div>
+      }
+      description="팀원들의 평가 참여도가 높을수록 분석 결과가 정확해요."
+      titleIcon={<Sparkles className="h-6 w-6 stroke-purple-600" />}
+      footer={
+        <Link href="/mypage">
+          <MessageBox.MessageConfirmButton text="내 평가 결과 보러가기" isPrimary={true} />
+        </Link>
+      }
+    />
+  );
+};
+
+// 오류 메시지창(유효성 검사)
+const ErrorMessage = () => {
+  const { closeModal } = useModalStore();
+
+  return (
+    <MessageBox
+      title={<div>모든 항목을 작성해주세요.</div>}
+      description="누락된 응답이 있습니다. 모든 질문에 답변해주세요."
+      titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
+      footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
+    />
+  );
+};

--- a/src/components/domain/survey/answerRow/CheckBoxRow.tsx
+++ b/src/components/domain/survey/answerRow/CheckBoxRow.tsx
@@ -4,7 +4,6 @@ import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 
 interface CheckBoxRowProps {
   index: number;
-  name: string;
   revieweeName: string;
   iconIndex: number;
   questionIndex: number;

--- a/src/components/domain/survey/answerRow/CheckBoxRow.tsx
+++ b/src/components/domain/survey/answerRow/CheckBoxRow.tsx
@@ -1,10 +1,11 @@
+import { cn } from '@/lib/utils';
 import type { UseFormRegister } from 'react-hook-form';
 import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 
 interface CheckBoxRowProps {
   index: number;
   name: string;
-  member: string;
+  revieweeName: string;
   iconIndex: number;
   questionIndex: number;
   register: UseFormRegister<Record<string, unknown>>;
@@ -12,22 +13,28 @@ interface CheckBoxRowProps {
 
 export default function CheckBoxRow({
   index,
-  member,
+  revieweeName,
   register,
   iconIndex,
   questionIndex,
 }: CheckBoxRowProps) {
+  const backgroundColor = index % 2 === 1 ? 'bg-gray-100' : 'bg-gray-50';
+
   return (
-    <div className="mb-2 flex w-full items-center justify-between rounded-[20px] bg-gray-100 px-4 py-2 md:px-8">
-      <div className="flex items-center gap-4">
-        <CirclePlanetIcon className="bg-gray-200" iconIndex={iconIndex} />
-        <span className="mr-4 mobile1">{member}</span>
-        <input
-          type="checkbox"
-          {...register(`responses[${questionIndex}].responseDetails[${index}].response.choice`)}
-          className="h-5 w-5 appearance-none rounded border-2 border-gray-400 checked:border-purple-500 checked:bg-purple-500"
-        />
+    <div
+      className={cn(
+        'mb-2 flex w-full items-center justify-between rounded-[20px] px-4 py-2 md:px-8',
+        backgroundColor,
+      )}>
+      <div className="flex max-w-[250px] items-center gap-2">
+        <CirclePlanetIcon className="bg-gray-100" iconIndex={iconIndex} />
+        <span className="mr-4 mobile1">{revieweeName}</span>
       </div>
+      <input
+        type="checkbox"
+        {...register(`responses[${questionIndex}].responseDetails[${index}].response.choice`)}
+        className="mr-4 h-5 w-5 appearance-none rounded border-2 border-gray-400 checked:border-purple-500 checked:bg-purple-500"
+      />
     </div>
   );
 }

--- a/src/components/domain/survey/answerRow/RatingRow.tsx
+++ b/src/components/domain/survey/answerRow/RatingRow.tsx
@@ -34,27 +34,27 @@ export default function RatingRow({
       <RadioGroup className="flex items-center space-x-4 md:space-x-8 lg:space-x-20">
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value={1}
+          value="1"
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value={2}
+          value="2"
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value={3}
+          value="3"
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value={4}
+          value="4"
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value={5}
+          value="5"
           register={register}
         />
       </RadioGroup>

--- a/src/components/domain/survey/answerRow/RatingRow.tsx
+++ b/src/components/domain/survey/answerRow/RatingRow.tsx
@@ -7,7 +7,7 @@ import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 interface RatingRowProps {
   index: number;
   name: string;
-  member: string;
+  revieweeName: string;
   iconIndex: number;
   questionIndex: number;
   register: UseFormRegister<Record<string, unknown>>;
@@ -15,7 +15,7 @@ interface RatingRowProps {
 
 export default function RatingRow({
   index,
-  member,
+  revieweeName,
   register,
   iconIndex,
   questionIndex,
@@ -28,9 +28,9 @@ export default function RatingRow({
         'mb-2 flex w-full items-center justify-between rounded-[20px] px-4 py-2 md:px-8',
         backgroundColor,
       )}>
-      <div className="flex items-center gap-4">
+      <div className="flex max-w-[250px] items-center gap-2">
         <CirclePlanetIcon className="bg-gray-100" iconIndex={iconIndex} />
-        <span className="mobile1">{member}</span>
+        <span className="mobile1">{revieweeName}</span>
       </div>
       <RadioGroup className="flex items-center space-x-4 md:space-x-8 lg:space-x-20">
         <CustomRadioButton

--- a/src/components/domain/survey/answerRow/RatingRow.tsx
+++ b/src/components/domain/survey/answerRow/RatingRow.tsx
@@ -35,27 +35,27 @@ export default function RatingRow({
       <RadioGroup className="flex items-center space-x-4 md:space-x-8 lg:space-x-20">
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value="1"
+          value={1}
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value="2"
+          value={2}
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value="3"
+          value={3}
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value="4"
+          value={4}
           register={register}
         />
         <CustomRadioButton
           name={`responses[${questionIndex}].responseDetails[${index}].response.score`}
-          value="5"
+          value={5}
           register={register}
         />
       </RadioGroup>

--- a/src/components/domain/survey/answerRow/RatingRow.tsx
+++ b/src/components/domain/survey/answerRow/RatingRow.tsx
@@ -6,7 +6,6 @@ import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 
 interface RatingRowProps {
   index: number;
-  name: string;
   revieweeName: string;
   iconIndex: number;
   questionIndex: number;

--- a/src/components/domain/survey/answerRow/TextRow.tsx
+++ b/src/components/domain/survey/answerRow/TextRow.tsx
@@ -9,6 +9,7 @@ interface TextRowProps {
   iconIndex: number;
   questionIndex: number;
   register: UseFormRegister<Record<string, unknown>>;
+  indicator: '강점' | '보완점';
 }
 
 export default function TextRow({
@@ -17,6 +18,7 @@ export default function TextRow({
   register,
   iconIndex,
   questionIndex,
+  indicator,
 }: TextRowProps) {
   return (
     <div className="mb-2 flex w-full rounded-[20px] bg-gray-100 py-2 md:px-8">
@@ -27,7 +29,7 @@ export default function TextRow({
       <div className="flex w-[75%] flex-col space-y-3">
         <MaxLengthMultiTextArea
           maxLength={50}
-          placeholder="강점을 알려 주세요."
+          placeholder={`${indicator}을 알려 주세요.`}
           className="h-[40px] w-full max-w-[670px] border-2"
           {...register(
             `responses[${questionIndex}].responseDetails[${index}].response.description`,
@@ -35,7 +37,7 @@ export default function TextRow({
         />
         <MaxLengthMultiTextArea
           maxLength={200}
-          placeholder="자세한 예를 들어 설명해 강점을 알려 주세요."
+          placeholder={`자세한 예를 들어 설명해 ${indicator}을 알려 주세요.`}
           className="h-[60px] w-full max-w-[670px] border-2"
           {...register(`responses[${questionIndex}].responseDetails[${index}].response.example`)}
         />

--- a/src/components/domain/survey/answerRow/TextRow.tsx
+++ b/src/components/domain/survey/answerRow/TextRow.tsx
@@ -4,7 +4,6 @@ import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 
 interface TextRowProps {
   index: number;
-  name: string;
   revieweeName: string;
   iconIndex: number;
   questionIndex: number;

--- a/src/components/domain/survey/answerRow/TextRow.tsx
+++ b/src/components/domain/survey/answerRow/TextRow.tsx
@@ -5,7 +5,7 @@ import CirclePlanetIcon from '../../user/CirclePlanetIcon';
 interface TextRowProps {
   index: number;
   name: string;
-  member: string;
+  revieweeName: string;
   iconIndex: number;
   questionIndex: number;
   register: UseFormRegister<Record<string, unknown>>;
@@ -14,7 +14,7 @@ interface TextRowProps {
 
 export default function TextRow({
   index,
-  member,
+  revieweeName,
   register,
   iconIndex,
   questionIndex,
@@ -22,15 +22,15 @@ export default function TextRow({
 }: TextRowProps) {
   return (
     <div className="mb-2 flex w-full rounded-[20px] bg-gray-100 py-2 md:px-8">
-      <div className="flex items-center gap-4">
+      <div className="flex w-[320px] items-center gap-4">
         <CirclePlanetIcon className="bg-gray-200" iconIndex={iconIndex} />
-        <span className="mr-4 mobile1">{member}</span>
+        <span className="mr-4 mobile1">{revieweeName}</span>
       </div>
-      <div className="flex w-[75%] flex-col space-y-3">
+      <div className="flex w-full flex-col space-y-3">
         <MaxLengthMultiTextArea
           maxLength={50}
           placeholder={`${indicator}을 알려 주세요.`}
-          className="h-[40px] w-full max-w-[670px] border-2"
+          className="h-[40px] w-full border-2"
           {...register(
             `responses[${questionIndex}].responseDetails[${index}].response.description`,
           )}
@@ -38,7 +38,7 @@ export default function TextRow({
         <MaxLengthMultiTextArea
           maxLength={200}
           placeholder={`자세한 예를 들어 설명해 ${indicator}을 알려 주세요.`}
-          className="h-[60px] w-full max-w-[670px] border-2"
+          className="h-[60px] w-full border-2"
           {...register(`responses[${questionIndex}].responseDetails[${index}].response.example`)}
         />
       </div>

--- a/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
+++ b/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
@@ -19,7 +19,7 @@ export default function CheckBoxAnswer({
       question={question.text}
       stepNumber={stepNumber}>
       <div className="w-full space-y-4">
-        {teamMembers.map((member, index) => (
+        {teamMembers?.map((member, index) => (
           <CheckBoxRow
             key={index}
             name={`responses[${stepNumber - 1}].responseDetails[${index}].response.choice`}
@@ -29,7 +29,7 @@ export default function CheckBoxAnswer({
             questionIndex={stepNumber - 1}
             index={index}
           />
-        ))}
+        )) ?? <p>팀원 정보를 불러올 수 없습니다.</p>}
       </div>
     </SurveyLayout>
   );

--- a/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
+++ b/src/components/domain/survey/answerType/CheckBoxAnswer.tsx
@@ -19,11 +19,11 @@ export default function CheckBoxAnswer({
       question={question.text}
       stepNumber={stepNumber}>
       <div className="w-full space-y-4">
-        {teamMembers?.map((member, index) => (
+        {teamMembers?.map((revieweeName, index) => (
           <CheckBoxRow
             key={index}
             name={`responses[${stepNumber - 1}].responseDetails[${index}].response.choice`}
-            member={member}
+            revieweeName={revieweeName}
             register={register}
             iconIndex={index}
             questionIndex={stepNumber - 1}

--- a/src/components/domain/survey/answerType/RatingAnswer.tsx
+++ b/src/components/domain/survey/answerType/RatingAnswer.tsx
@@ -22,7 +22,7 @@ export default function RatingAnswer({
       <div className="flex flex-col items-end gap-2">
         <RatingScale />
         <div className="w-full space-y-2">
-          {teamMembers.map((member, index) => (
+          {teamMembers?.map((member, index) => (
             <RatingRow
               key={index}
               name={`responses[${stepNumber - 1}].responseDetails[${index}].response.score`}
@@ -32,7 +32,7 @@ export default function RatingAnswer({
               index={index}
               questionIndex={stepNumber - 1}
             />
-          ))}
+          )) ?? <p>팀원 정보를 불러올 수 없습니다.</p>}
         </div>
       </div>
     </SurveyLayout>

--- a/src/components/domain/survey/answerType/RatingAnswer.tsx
+++ b/src/components/domain/survey/answerType/RatingAnswer.tsx
@@ -22,11 +22,11 @@ export default function RatingAnswer({
       <div className="flex flex-col items-end gap-2">
         <RatingScale />
         <div className="w-full space-y-2">
-          {teamMembers?.map((member, index) => (
+          {teamMembers?.map((revieweeName, index) => (
             <RatingRow
               key={index}
               name={`responses[${stepNumber - 1}].responseDetails[${index}].response.score`}
-              member={member}
+              revieweeName={revieweeName}
               register={register}
               iconIndex={index}
               index={index}

--- a/src/components/domain/survey/answerType/TextAnswer.tsx
+++ b/src/components/domain/survey/answerType/TextAnswer.tsx
@@ -36,11 +36,11 @@ export default function TextAnswer({
       question={question.text}
       stepNumber={stepNumber}>
       {(stepNumber === 13 || stepNumber === 14) && <Instruction indicator={indicator} />}
-      {teamMembers?.map((member, index) => (
+      {teamMembers?.map((revieweeName, index) => (
         <TextRow
           key={index}
           name={`responses[${stepNumber - 1}].responseDetails[${index}].response`}
-          member={member}
+          revieweeName={revieweeName}
           register={register}
           iconIndex={index}
           questionIndex={stepNumber - 1}

--- a/src/components/domain/survey/answerType/TextAnswer.tsx
+++ b/src/components/domain/survey/answerType/TextAnswer.tsx
@@ -36,7 +36,7 @@ export default function TextAnswer({
       question={question.text}
       stepNumber={stepNumber}>
       {(stepNumber === 13 || stepNumber === 14) && <Instruction indicator={indicator} />}
-      {teamMembers.map((member, index) => (
+      {teamMembers?.map((member, index) => (
         <TextRow
           key={index}
           name={`responses[${stepNumber - 1}].responseDetails[${index}].response`}
@@ -47,7 +47,7 @@ export default function TextAnswer({
           index={index}
           indicator={indicator}
         />
-      ))}
+      )) ?? <p>팀원 정보를 불러올 수 없습니다.</p>}
     </SurveyLayout>
   );
 }

--- a/src/components/domain/survey/answerType/TextAnswer.tsx
+++ b/src/components/domain/survey/answerType/TextAnswer.tsx
@@ -27,14 +27,15 @@ export default function TextAnswer({
 }: TextAnswerProps) {
   const { register } = useFormContext<Record<string, unknown>>();
 
+  const indicator = stepNumber === 13 ? '강점' : '보완점';
+
   return (
     <SurveyLayout
       currentStep={currentStep}
       totalSteps={totalSteps}
       question={question.text}
       stepNumber={stepNumber}>
-      {stepNumber === 13 && <Instruction indicator="강점" />}
-      {stepNumber === 14 && <Instruction indicator="보완점" />}
+      {(stepNumber === 13 || stepNumber === 14) && <Instruction indicator={indicator} />}
       {teamMembers.map((member, index) => (
         <TextRow
           key={index}
@@ -44,6 +45,7 @@ export default function TextAnswer({
           iconIndex={index}
           questionIndex={stepNumber - 1}
           index={index}
+          indicator={indicator}
         />
       ))}
     </SurveyLayout>

--- a/src/models/survey/surveyApiModels.ts
+++ b/src/models/survey/surveyApiModels.ts
@@ -47,6 +47,7 @@ export interface FormResponseDetails {
 }
 
 export interface SurveyFormValues {
+  reviewerEmail: string;
   responses: {
     questionOrder: string;
     questionType: 'singleChoice' | 'multipleChoiceMember' | 'shortAnswer';
@@ -54,7 +55,7 @@ export interface SurveyFormValues {
     responseDetails: {
       revieweeEmail: string;
       response: {
-        score?: number;
+        score?: number | string;
         choice?: boolean;
         description?: string;
         example?: string;

--- a/src/models/survey/surveyApiModels.ts
+++ b/src/models/survey/surveyApiModels.ts
@@ -8,9 +8,12 @@ export interface SurveyLinkResponse {
   success: boolean;
   status: number;
   data: {
-    revieweeEmails: string[];
-    reviewerEmail: string;
+    revieweeInfoList: Array<{
+      revieweeEmail: string;
+      revieweeName: string;
+    }>;
     projectId: string;
+    reviewerEmail: string;
   };
 }
 
@@ -18,7 +21,6 @@ export interface SurveyLinkErrorResponse {
   code: string;
   message: string;
 }
-
 export interface SendSurveyLinkRequest {
   projectId: number;
 }

--- a/src/models/survey/surveyModels.ts
+++ b/src/models/survey/surveyModels.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export const SURVEY_QUESTION_TYPE = {
   SingleChoice: 'singleChoice',
   MultipleChoiceMember: 'multipleChoiceMember',
@@ -6,14 +8,18 @@ export const SURVEY_QUESTION_TYPE = {
 
 export type SurveyQuestionsType = (typeof SURVEY_QUESTION_TYPE)[keyof typeof SURVEY_QUESTION_TYPE];
 
+export const SURVEY_QUESTION_CATEGORY = {
+  Responsibility: 'responsibility',
+  Initiative: 'initiative',
+  ProblemSolving: 'problemSolving',
+  Communication: 'communication',
+  Teamwork: 'teamwork',
+  Strength: 'strength',
+  ImprovementPoint: 'improvementPoint',
+} as const;
+
 export type SurveyQuestionCategoryType =
-  | 'responsibility'
-  | 'initiative'
-  | 'problemSolving'
-  | 'communication'
-  | 'teamwork'
-  | 'strength'
-  | 'improvementPoint';
+  (typeof SURVEY_QUESTION_CATEGORY)[keyof typeof SURVEY_QUESTION_CATEGORY];
 
 export interface SurveyQuestion {
   id: number;
@@ -44,3 +50,37 @@ export interface SurveyStep {
   teamMembers: string[];
   options?: string[];
 }
+
+// Zod 스키마 정의
+const surveyResponseSchema = z.object({
+  score: z.number().int().min(1).max(5).optional(),
+  choice: z.boolean().optional(),
+  description: z.string().optional(),
+  example: z.string().optional(),
+});
+
+const surveyResponseDetailsSchema = z.object({
+  revieweeEmail: z.string().email(),
+  response: surveyResponseSchema,
+});
+
+const surveyQuestionResponseSchema = z.object({
+  questionOrder: z.string(),
+  questionType: z.enum(['singleChoice', 'multipleChoiceMember', 'shortAnswer']),
+  questionCategory: z.enum([
+    'responsibility',
+    'initiative',
+    'problemSolving',
+    'communication',
+    'teamwork',
+    'strength',
+    'improvementPoint',
+  ]),
+  responseDetails: z.array(surveyResponseDetailsSchema).min(1),
+});
+
+export const surveyFormSchema = z.object({
+  responses: z.array(surveyQuestionResponseSchema),
+});
+
+export type SurveyFormValues = z.infer<typeof surveyFormSchema>;

--- a/src/models/survey/surveyModels.ts
+++ b/src/models/survey/surveyModels.ts
@@ -90,13 +90,15 @@ export const surveyFormSchema = z
   })
   .refine(
     (data) =>
-      data.responses.every((response) =>
-        response.responseDetails.every((detail) =>
-          Object.values(detail.response).some(
-            (value) => value !== undefined && value !== null && value !== '',
-          ),
-        ),
-      ),
+      data.responses.every((response) => {
+        return response.responseDetails.every((detail) => {
+          const responseValues = Object.values(detail.response);
+          return (
+            responseValues.length > 0 &&
+            responseValues.every((value) => value !== undefined && value !== null && value !== '')
+          );
+        });
+      }),
     {
       message: '모든 문항에 적어도 하나의 응답이 필요합니다.',
     },

--- a/src/models/survey/surveyModels.ts
+++ b/src/models/survey/surveyModels.ts
@@ -33,7 +33,7 @@ export interface CommonProps {
   totalSteps: number;
   question: { id: number; text: string };
   stepNumber: number;
-  teamMembers: string[];
+  teamMembers: string[] | undefined;
   options?: string[];
 }
 


### PR DESCRIPTION
## 💡 ISSUE 번호

#114 

<br/>

## 🔎 작업 내용

- 평가 질문지 정보 불러오기 api 변동에 따른 에러처리 추가 및 models 변경
- surveyModels에 Zod 스키마 정의 추가
- 평가하기 제출 시 유효성 검사 추가
- 유효성 검사 시 메시지 박스 추가

<br/>

## **QA 수정건**
- 평가지 13,14번 placeholder indicator 추가
- ![image](https://github.com/user-attachments/assets/5f2f8e90-8c06-4a5b-af17-c0bcdb241aa4)
-  평가 페이지 이메일 -> 이름 변경, UI 수정
![image](https://github.com/user-attachments/assets/01b112a1-9674-4cb0-9f1e-cee08e08ce6d)

<br/>

## 📢 주의 및 리뷰 요청

- 원래 캐러셀 넘길 때마다 onchange로 실시간으로 누락된 값을 추적해서 유효성 검사를 진행하고 싶었는데, 너무....어렵더라고요...그래서 캐러셀 마지막 페이지에서 등록하기 버튼 클릭 시 전체 응답에 대한 유효성 검사를 진행하는 방식으로 짰습니다...
- 전체 응답에 대한 유효성 체크라 모달에서처럼 하단에 메시지를 띄워주는건 좀 어색할 것 같아서 메시지 박스로 처리했습니다.
![스크린샷 2024-07-29 오전 5 43 35](https://github.com/user-attachments/assets/8e689c3e-59c5-4140-852f-fb936136c127)
- 현재 객관식에 대한 응답은 number 인데, 라디오 버튼으로 값을 받고 form에 태우니까 보낼 때 객체가 string으로 바뀌더라고요. 백엔드에서 string 상관없다고 해서 string -> number로 바꾸는 로직은 추가하지 않았습니다. 다만 저도 평가지 작업하면서 number로 설정해준 부분이 많아서, 일단은 number | string 둘 다 가능하게 해두었습니다. 따라서 타입이 좀 섞여 있는 상태입니다. 이 부분 추후 리팩토링 해보겠습니다. 참고 부탁드립니다...




<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
