### PR TITLE
Fix/#130 회원가입 flow 수정 (useTimer 수정 후 영향)

### DIFF
--- a/src/app/layout/header/GlobalHeader.tsx
+++ b/src/app/layout/header/GlobalHeader.tsx
@@ -22,23 +22,16 @@ import {
 import { PageSpinner } from '@/components/common/spinner';
 
 export default function GlobalHeader() {
-  const { openModal, closeModal } = useModalStore();
+  const { openModal } = useModalStore();
   const { isLoggedIn } = useAuthStore();
   const logoutMutation = useLogout();
-
-  const handleSignupSuccess = () => {
-    closeModal();
-    setTimeout(() => {
-      openModal(<LoginModal />);
-    }, 200);
-  };
 
   const handleOpenLoginModal = () => {
     openModal(<LoginModal />);
   };
 
   const handleOpenSignupModal = () => {
-    openModal(<SignupModal onSuccess={handleSignupSuccess} />);
+    openModal(<SignupModal />);
   };
 
   const handleLogout = () => {

--- a/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
+++ b/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
@@ -34,17 +34,16 @@ export default function ResetPasswordModal() {
   const { openModal, closeModal } = useModalStore();
 
   // mutation
-  const sendEmailCodeMutation = useSendEmailCode(() => {});
-  const verifyAuthCodeMutation = useVerifyAuthCode(() => {});
+  const sendEmailCodeMutation = useSendEmailCode();
+  const verifyAuthCodeMutation = useVerifyAuthCode();
   const resetPasswordMutation = useResetPassword();
 
   const [isCertified, setIsCertified] = useState(false);
-  const [isCodeSended, setIsCodeSended] = useState<boolean>(false); // 인증코드 전송 완료 상태
+  const [isCodeSent, setIsCodeSent] = useState<boolean>(false); // 인증코드 전송 완료 상태
 
   const handleTimerEnd = () => {
-    setIsCodeSended(false);
-
-    formMethods.setValue('certification', '');
+    setIsCodeSent(false);
+    setValue('certification', '');
   };
 
   const { timeLeft, startTimer, isRunning } = useTimer(300, handleTimerEnd);
@@ -64,6 +63,7 @@ export default function ResetPasswordModal() {
     handleSubmit,
     formState: { errors, isValid },
     watch,
+    setValue,
     getValues,
     setError,
   } = formMethods;
@@ -83,7 +83,7 @@ export default function ResetPasswordModal() {
         authType: 'RESET_PASSWORD',
       });
       // 인증번호 전송에 성공하면, 타이머 시작
-      setIsCodeSended(true);
+      setIsCodeSent(true);
       startTimer();
     } catch (error) {
       console.error('인증번호 발송 실패:', error);
@@ -158,13 +158,13 @@ export default function ResetPasswordModal() {
                         id={`${id}-reset-password-email`}
                         placeholder="prism12@gmail.com"
                         className="w-full flex-grow sm:w-auto"
-                        disabled={isCodeSended || sendEmailCodeMutation.isPending}
+                        disabled={isCodeSent || sendEmailCodeMutation.isPending}
                       />
                     </FormControl>
                     <Button
                       type="button"
                       className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
-                      disabled={isCodeSended || !isEmailValid}
+                      disabled={isCodeSent || !isEmailValid}
                       pending={sendEmailCodeMutation.isPending}
                       onClick={handleSendEmailCode}>
                       인증번호 받기
@@ -194,7 +194,7 @@ export default function ResetPasswordModal() {
                           className="w-full pr-12"
                           disabled={isCertified}
                         />
-                        {isCodeSended && !isCertified && isRunning && (
+                        {isCodeSent && !isCertified && isRunning && (
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 transform text-danger-500">
                             {formatSecondToMMSS(timeLeft)}
                           </span>
@@ -204,7 +204,7 @@ export default function ResetPasswordModal() {
                     <Button
                       type="button"
                       className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
-                      disabled={!isCodeSended || !isAuthCodeValid || isCertified || !isEmailValid}
+                      disabled={!isCodeSent || !isAuthCodeValid || isCertified || !isEmailValid}
                       pending={verifyAuthCodeMutation.isPending}
                       onClick={handleVerifyAuthCode}>
                       인증하기

--- a/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
+++ b/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useState } from 'react';
+import { useId, useState } from 'react';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useModalStore } from '@/stores/modalStore';
 import { useForm } from 'react-hook-form';
@@ -26,18 +26,24 @@ import {
 } from '@/components/ui/form';
 import ModalLayout from '@/components/common/modal/ModalLayout';
 import LoginModal from '../login/LoginModal';
+import { cn } from '@/lib/utils';
 
 export default function ResetPasswordModal() {
   const id = useId();
   const isSmallScreen = useMediaQuery('(max-width: 430px)');
-  const [isEmailChecked, setIsEmailChecked] = useState(false);
-  const [isCertified, setIsCertified] = useState(false);
-  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
-
   const { openModal, closeModal } = useModalStore();
 
+  // mutation
+  const sendEmailCodeMutation = useSendEmailCode(() => {});
+  const verifyAuthCodeMutation = useVerifyAuthCode(() => {});
+  const resetPasswordMutation = useResetPassword();
+
+  const [isCertified, setIsCertified] = useState(false);
+  const [isCodeSended, setIsCodeSended] = useState<boolean>(false); // 인증코드 전송 완료 상태
+
   const handleTimerEnd = () => {
-    setIsButtonDisabled(false);
+    setIsCodeSended(false);
+
     formMethods.setValue('certification', '');
   };
 
@@ -65,46 +71,28 @@ export default function ResetPasswordModal() {
   const email = watch('email');
   const certification = watch('certification');
 
-  const isEmailValid = !errors.email && email && email.trim().length > 0;
-  const isCertificationValid = !errors.certification && certification.length > 0;
-
-  const sendEmailCodeMutation = useSendEmailCode(() => {
-    startTimer();
-    setIsEmailChecked(true);
-  });
-
-  const verifyAuthCodeMutation = useVerifyAuthCode(() => {
-    setIsCertified(true);
-  });
-
-  const resetPasswordMutation = useResetPassword(() => {
-    formMethods.reset();
-    closeModal();
-    openModal(<LoginModal />);
-  });
-
-  useEffect(() => {
-    const shouldDisable = !isEmailValid || isRunning || sendEmailCodeMutation.isPending;
-    setIsButtonDisabled(shouldDisable);
-  }, [isEmailValid, isRunning, sendEmailCodeMutation.isPending]);
+  const isEmailValid = !errors.email && email.length > 0;
+  const isAuthCodeValid = !errors.certification && certification.length > 0;
 
   // 인증번호 전송
   const handleSendEmailCode = async () => {
+    const email = getValues('email');
     try {
-      setIsButtonDisabled(true);
       await sendEmailCodeMutation.mutateAsync({
         email,
         authType: 'RESET_PASSWORD',
       });
+      // 인증번호 전송에 성공하면, 타이머 시작
+      setIsCodeSended(true);
       startTimer();
     } catch (error) {
       console.error('인증번호 발송 실패:', error);
-      setIsButtonDisabled(false);
     }
   };
 
   // 인증번호 확인
   const handleVerifyAuthCode = async () => {
+    const email = getValues('email');
     const authCode = getValues('certification');
     try {
       await verifyAuthCodeMutation.mutateAsync({
@@ -112,6 +100,7 @@ export default function ResetPasswordModal() {
         authCode,
         authType: 'RESET_PASSWORD',
       });
+      setIsCertified(true);
     } catch (error) {
       setError('certification', { type: 'manual', message: '인증코드가 일치하지 않습니다.' });
       console.error('인증코드 확인 실패:', error);
@@ -119,18 +108,25 @@ export default function ResetPasswordModal() {
   };
 
   // 비밀번호 재설정
-  const onSubmit = async (data: ResetPasswordForm) => {
+  const onResetPasswordSubmit = async (data: ResetPasswordForm) => {
     try {
       await resetPasswordMutation.mutateAsync({
         email: data.email,
         authCode: data.certification,
         password: data.newPassword,
       });
+      closeModal();
+      alert('비밀번호가 성공적으로 재설정되었습니다.');
+      setTimeout(() => {
+        openModal(<LoginModal />);
+      }, 200);
     } catch (error) {
       console.error('비밀번호 재설정 실패:', error);
-      alert('비밀번호 재설정 중 오류가 발생했습니다. 다시 시도해 주세요.');
     }
   };
+
+  // 라벨 텍스트 스타일 (반응형)
+  const labelStyle = isSmallScreen ? 'mobile2' : 'mobile1';
 
   return (
     <ModalLayout
@@ -140,36 +136,35 @@ export default function ResetPasswordModal() {
         <ModalLayout.ConfirmButton
           title="비밀번호 변경하기"
           isSmallScreen={isSmallScreen}
-          onClick={handleSubmit(onSubmit)}
+          onClick={handleSubmit(onResetPasswordSubmit)}
           disabled={!isValid || !isCertified}
           pending={resetPasswordMutation.isPending}
         />
       }>
       <Form {...formMethods}>
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={handleSubmit(onResetPasswordSubmit)}>
           <div className="mt-12 grid w-full max-w-[420px] items-center gap-1">
             <FormField
               control={formMethods.control}
               name="email"
               render={({ field }) => (
                 <FormItem className="relative">
-                  <FormLabel className={`text-black ${isSmallScreen ? 'mobile2' : 'mobile1'}`}>
-                    이메일 주소
-                  </FormLabel>
+                  <FormLabel className={cn('text-black', labelStyle)}>이메일 주소</FormLabel>
                   <div className="flex flex-col items-center justify-between sm:flex-row">
                     <FormControl>
                       <Input
+                        {...field}
                         type="email"
                         id={`${id}-reset-password-email`}
                         placeholder="prism12@gmail.com"
-                        {...field}
-                        disabled={isEmailChecked}
                         className="w-full flex-grow sm:w-auto"
+                        disabled={isCodeSended || sendEmailCodeMutation.isPending}
                       />
                     </FormControl>
                     <Button
+                      type="button"
                       className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
-                      disabled={isButtonDisabled}
+                      disabled={isCodeSended || !isEmailValid}
                       pending={sendEmailCodeMutation.isPending}
                       onClick={handleSendEmailCode}>
                       인증번호 받기
@@ -187,21 +182,19 @@ export default function ResetPasswordModal() {
               name="certification"
               render={({ field }) => (
                 <FormItem className="relative">
-                  <FormLabel className={`text-black ${isSmallScreen ? 'mobile2' : 'mobile1'}`}>
-                    인증번호
-                  </FormLabel>
+                  <FormLabel className={cn('text-black', labelStyle)}>인증번호</FormLabel>
                   <div className="flex flex-col items-center justify-between sm:flex-row">
                     <FormControl>
                       <div className="relative w-full flex-grow sm:w-auto">
                         <Input
+                          {...field}
                           type="text"
                           id={`${id}-reset-password-certification`}
                           placeholder="이메일로 전송된 인증번호를 입력해 주세요."
-                          {...field}
                           className="w-full pr-12"
                           disabled={isCertified}
                         />
-                        {timeLeft > 0 && !isCertified && (
+                        {isCodeSended && !isCertified && isRunning && (
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 transform text-danger-500">
                             {formatSecondToMMSS(timeLeft)}
                           </span>
@@ -209,13 +202,9 @@ export default function ResetPasswordModal() {
                       </div>
                     </FormControl>
                     <Button
+                      type="button"
                       className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
-                      disabled={
-                        !isCertificationValid ||
-                        timeLeft === 0 ||
-                        isCertified ||
-                        verifyAuthCodeMutation.isPending
-                      }
+                      disabled={!isCodeSended || !isAuthCodeValid || isCertified || !isEmailValid}
                       pending={verifyAuthCodeMutation.isPending}
                       onClick={handleVerifyAuthCode}>
                       인증하기
@@ -237,15 +226,15 @@ export default function ResetPasswordModal() {
               render={({ field }) => (
                 <FormItem className="relative">
                   <FormLabel
-                    className={`text-black ${isSmallScreen ? 'mobile2' : 'mobile1'}`}
+                    className={cn('text-black', labelStyle)}
                     htmlFor={`${id}-new-password`}>
                     새 비밀번호
                   </FormLabel>
                   <FormControl>
                     <PasswordInput
+                      {...field}
                       id={`${id}-new-password`}
                       placeholder="비밀번호"
-                      {...field}
                       className="w-full"
                       autoComplete="new-password"
                     />
@@ -263,15 +252,15 @@ export default function ResetPasswordModal() {
               render={({ field }) => (
                 <FormItem className="relative">
                   <FormLabel
-                    className={`text-black ${isSmallScreen ? 'mobile2' : 'mobile1'}`}
+                    className={cn('text-black', labelStyle)}
                     htmlFor={`${id}-verify-new-password`}>
                     비밀번호 확인
                   </FormLabel>
                   <FormControl>
                     <PasswordInput
+                      {...field}
                       id={`${id}-verify-new-password`}
                       placeholder="비밀번호 확인"
-                      {...field}
                       className="w-full"
                       autoComplete="new-password"
                     />

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -38,17 +38,17 @@ export default function SignupModal() {
   // mutation
   const checkEmailExistMutation = useCheckEmailExists();
   const signupMutation = useSignup();
-  const sendCodeMutation = useSendEmailCode(() => {});
-  const verifyCodeMutation = useVerifyAuthCode(() => {});
+  const sendCodeMutation = useSendEmailCode();
+  const verifyCodeMutation = useVerifyAuthCode();
 
   const [isAgreed, setIsAgreed] = useReducer((state: boolean) => !state, false); // 약관 동의 여부
   const [isEmailExistChecked, setIsEmailExistChecked] = useState<boolean>(false); // 이메일 중복 확인 완료 상태
   const [isCertified, setIsCertified] = useState<boolean>(false); // 인증코드 확인 완료 상태
-  const [isCodeSended, setIsCodeSended] = useState<boolean>(false); // 인증코드 전송 완료 상태
+  const [isCodeSent, setIsCodeSent] = useState<boolean>(false); // 인증코드 전송 완료 상태
 
   const handleTimerEnd = () => {
-    setIsCodeSended(false);
-    formMethods.setValue('certification', '');
+    setIsCodeSent(false);
+    setValue('certification', '');
     alert('인증시간이 만료되었습니다. 다시 시도해주세요.');
   };
 
@@ -70,6 +70,7 @@ export default function SignupModal() {
     handleSubmit,
     formState: { errors, isValid },
     watch,
+    setValue,
     getValues,
     setError,
     clearErrors,
@@ -103,7 +104,7 @@ export default function SignupModal() {
     try {
       await sendCodeMutation.mutateAsync({ email, authType: 'SIGNUP' });
       // 인증번호 전송에 성공하면, 타이머 시작
-      setIsCodeSended(true);
+      setIsCodeSent(true);
       startTimer();
     } catch (error) {
       console.error(`인증번호 받기 실패: ${error}`);
@@ -220,7 +221,7 @@ export default function SignupModal() {
                         className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
                         onClick={handleSendEmailCode}
                         pending={sendCodeMutation.isPending}
-                        disabled={isCodeSended}>
+                        disabled={isCodeSent}>
                         인증번호 받기
                       </Button>
                     ) : (
@@ -259,7 +260,7 @@ export default function SignupModal() {
                           disabled={isCertified}
                           autoComplete="off"
                         />
-                        {isCodeSended && !isCertified && isRunning && (
+                        {isCodeSent && !isCertified && isRunning && (
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 transform text-danger-500">
                             {formatSecondToMMSS(timeLeft)}
                           </span>
@@ -270,7 +271,7 @@ export default function SignupModal() {
                       type="button"
                       className="mt-2 h-[45px] w-full bg-purple-500 display6 hover:bg-purple-600 sm:ml-2 sm:mt-0 sm:w-auto"
                       disabled={
-                        !isCodeSended || !isAuthCodeValid || isCertified || !isEmailExistChecked
+                        !isCodeSent || !isAuthCodeValid || isCertified || !isEmailExistChecked
                       }
                       onClick={handleVerifyAuthCode}
                       pending={verifyCodeMutation.isPending}>

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -166,13 +166,14 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
         />
       }>
       <Form {...formMethods}>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="mt-8 grid w-full max-w-[420px] items-center gap-1">
+        <form className="mt-8 gap-8 flex-col-center" onSubmit={handleSubmit(onSubmit)}>
+          {/* 이름 */}
+          <div className="w-full">
             <FormField
               control={formMethods.control}
               name="name"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormLabel
                     className={cn('text-black', {
                       mobile2: isSmallScreen,
@@ -190,18 +191,20 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                       autoComplete="name"
                     />
                   </FormControl>
-                  <FormMessage>{errors.name?.message}</FormMessage>
+                  <FormMessage className="absolute -bottom-5 left-0">
+                    {errors.name?.message}
+                  </FormMessage>
                 </FormItem>
               )}
             />
           </div>
-
-          <div className="mt-6 grid w-full max-w-[420px] items-center gap-1">
+          {/* 이메일 주소 */}
+          <div className="w-full">
             <FormField
               control={formMethods.control}
               name="email"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormLabel
                     className={cn('text-black', {
                       mobile2: isSmallScreen,
@@ -242,18 +245,18 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                       </Button>
                     )}
                   </div>
-                  <FormMessage>{errors.email?.message}</FormMessage>
+                  <FormMessage className="absolute -bottom-5">{errors.email?.message}</FormMessage>
                 </FormItem>
               )}
             />
           </div>
-
-          <div className="mt-6 grid w-full max-w-[420px] items-center gap-1">
+          {/* 인증번호 */}
+          <div className="w-full">
             <FormField
               control={formMethods.control}
               name="certification"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormLabel
                     className={cn('text-black', {
                       mobile2: isSmallScreen,
@@ -273,7 +276,7 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                           disabled={isCertified}
                           autoComplete="off"
                         />
-                        {timeLeft > 0 && !isCertified && (
+                        {isSendingCode && !isCertified && (
                           <span className="absolute right-3 top-1/2 -translate-y-1/2 transform text-danger-500">
                             {formatSecondToMMSS(timeLeft)}
                           </span>
@@ -289,20 +292,24 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                     </Button>
                   </div>
                   {isCertified && (
-                    <p className="text-success-500 caption">인증이 완료되었습니다!</p>
+                    <p className="absolute -bottom-5 text-success-500 caption">
+                      인증이 완료되었습니다!
+                    </p>
                   )}
-                  <FormMessage>{errors.certification?.message}</FormMessage>
+                  <FormMessage className="absolute -bottom-5">
+                    {errors.certification?.message}
+                  </FormMessage>
                 </FormItem>
               )}
             />
           </div>
-
-          <div className="mt-6 grid w-full max-w-[420px] items-center gap-1">
+          {/* 비밀번호 */}
+          <div className="w-full">
             <FormField
               control={formMethods.control}
               name="password"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormLabel
                     className={cn('text-black', {
                       mobile2: isSmallScreen,
@@ -319,18 +326,20 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                       autoComplete="new-password"
                     />
                   </FormControl>
-                  <FormMessage>{errors.password?.message}</FormMessage>
+                  <FormMessage className="absolute -bottom-5">
+                    {errors.password?.message}
+                  </FormMessage>
                 </FormItem>
               )}
             />
           </div>
-
-          <div className="mb-6 mt-6 grid w-full max-w-[420px] items-center gap-1">
+          {/* 비밀번호 확인 */}
+          <div className="w-full">
             <FormField
               control={formMethods.control}
               name="verifyPassword"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormLabel
                     className={cn('text-black', {
                       mobile2: isSmallScreen,
@@ -347,7 +356,9 @@ export default function SignupModal({ onSuccess, afterClose }: SignupModalProps)
                       autoComplete="new-password"
                     />
                   </FormControl>
-                  <FormMessage>{errors.verifyPassword?.message}</FormMessage>
+                  <FormMessage className="absolute -bottom-5">
+                    {errors.verifyPassword?.message}
+                  </FormMessage>
                 </FormItem>
               )}
             />

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -124,7 +124,7 @@ export default function SignupModal() {
   };
 
   // 회원가입 제출
-  const onSubmit = async (data: SignupForm) => {
+  const onSignupSubmit = async (data: SignupForm) => {
     try {
       await signupMutation.mutateAsync({
         username: data.name,
@@ -161,13 +161,13 @@ export default function SignupModal() {
         <ModalLayout.ConfirmButton
           title="회원가입하기"
           isSmallScreen={isSmallScreen}
-          onClick={handleSubmit(onSubmit)}
+          onClick={handleSubmit(onSignupSubmit)}
           pending={signupMutation.isPending}
           disabled={!isValid || !isAgreed || !isCertified || !isEmailExistChecked}
         />
       }>
       <Form {...formMethods}>
-        <form className="mt-8 gap-8 flex-col-center" onSubmit={handleSubmit(onSubmit)}>
+        <form className="mt-8 gap-8 flex-col-center" onSubmit={handleSubmit(onSignupSubmit)}>
           {/* 이름 */}
           <div className="w-full">
             <FormField
@@ -178,10 +178,10 @@ export default function SignupModal() {
                   <FormLabel className={cn('text-black', labelStyle)}>이름</FormLabel>
                   <FormControl>
                     <Input
+                      {...field}
                       type="text"
                       id={`${id}-signup-name`}
                       placeholder="이름"
-                      {...field}
                       className="w-full"
                       autoComplete="name"
                     />
@@ -204,11 +204,11 @@ export default function SignupModal() {
                   <div className="flex flex-col items-center justify-between sm:flex-row">
                     <FormControl>
                       <Input
+                        {...field}
                         type="email"
                         id={`${id}-signup-email`}
                         placeholder="prism12@gmail.com"
-                        {...field}
-                        disabled={isEmailExistChecked} // 이메일 중복 확인이 끝나면 수정 불가
+                        disabled={isEmailExistChecked || sendCodeMutation.isPending} // 이메일 중복 확인이 끝나면 수정 불가
                         className="w-full flex-grow sm:w-auto"
                         autoComplete="username"
                       />
@@ -251,10 +251,10 @@ export default function SignupModal() {
                     <FormControl>
                       <div className="relative w-full flex-grow sm:w-auto">
                         <Input
+                          {...field}
                           type="text"
                           id={`${id}-signup-certification`}
                           placeholder="이메일로 전송된 인증번호를 입력해 주세요."
-                          {...field}
                           className="w-full pr-12"
                           disabled={isCertified}
                           autoComplete="off"
@@ -299,9 +299,9 @@ export default function SignupModal() {
                   <FormLabel className={cn('text-black', labelStyle)}>비밀번호</FormLabel>
                   <FormControl>
                     <PasswordInput
+                      {...field}
                       id={`${id}-signup-password`}
                       placeholder="비밀번호"
-                      {...field}
                       className="w-full"
                       autoComplete="new-password"
                     />
@@ -323,9 +323,9 @@ export default function SignupModal() {
                   <FormLabel className={cn('text-black', labelStyle)}>비밀번호 확인</FormLabel>
                   <FormControl>
                     <PasswordInput
+                      {...field}
                       id={`${id}-signup-verify-password`}
                       placeholder="비밀번호 확인"
-                      {...field}
                       className="w-full"
                       autoComplete="new-password"
                     />

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -122,13 +122,9 @@ export const useVerifyAuthCode = (successCallback: () => void) => {
   });
 };
 
-export const useResetPassword = (successCallback: () => void) => {
+export const useResetPassword = () => {
   return useMutation<ResetPasswordResponse, AxiosError, ResetPasswordRequest>({
     mutationFn: resetPassword,
-    onSuccess: () => {
-      if (successCallback) successCallback();
-      alert('비밀번호가 성공적으로 재설정되었습니다.');
-    },
     onError: (error) => {
       console.error('비밀번호 재설정 실패:', error);
       if (error instanceof AxiosError) {

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -95,11 +95,10 @@ export const useLogout = () => {
   });
 };
 
-export const useSendEmailCode = (successCallback: () => void) => {
+export const useSendEmailCode = () => {
   return useMutation<SendEmailCodeResponse, AxiosError, SendEmailCodeRequest>({
     mutationFn: sendEmailCode,
     onSuccess: () => {
-      if (successCallback) successCallback();
       alert('인증번호가 전송되었습니다.');
     },
     onError: (error) => {
@@ -109,12 +108,9 @@ export const useSendEmailCode = (successCallback: () => void) => {
   });
 };
 
-export const useVerifyAuthCode = (successCallback: () => void) => {
+export const useVerifyAuthCode = () => {
   return useMutation<VerifyAuthCodeResponse, AxiosError, VerifyAuthCodeRequest>({
     mutationFn: verifyAuthCode,
-    onSuccess: () => {
-      if (successCallback) successCallback();
-    },
     onError: (error) => {
       console.error('인증번호 인증 실패:', error);
       alert('인증번호 인증에 실패했습니다. 다시 시도해 주세요.');

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -9,6 +9,9 @@ import type {
   VerifyAuthCodeResponse,
   ResetPasswordRequest,
   ResetPasswordResponse,
+  EmailExistsResponse,
+  SignupResponse,
+  SignupRequest,
 } from '@/models/auth/authApiModels';
 import { useAuthStore } from '@/stores/authStore';
 import { useModalStore } from '@/stores/modalStore';
@@ -19,6 +22,8 @@ import {
   sendEmailCode,
   verifyAuthCode,
   resetPassword,
+  checkEmailExists,
+  signup,
 } from '../../services/api/authApi';
 import { useUserStore } from '@/stores/userStore';
 import { userDataByLoginUser } from '@/services/api/userApi';
@@ -130,6 +135,35 @@ export const useResetPassword = (successCallback: () => void) => {
         alert(error.message);
       } else {
         alert('비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.');
+      }
+    },
+  });
+};
+
+export const useCheckEmailExists = () => {
+  return useMutation<EmailExistsResponse, AxiosError, string>({
+    mutationFn: checkEmailExists,
+
+    onError: (error) => {
+      console.error('이메일 중복검사 실패:', error);
+      if (error instanceof AxiosError) {
+        alert(error.message);
+      } else {
+        alert('이메일 중복검사에 실패했습니다. 다시 시도해 주세요.');
+      }
+    },
+  });
+};
+
+export const useSignup = () => {
+  return useMutation<SignupResponse, AxiosError, SignupRequest>({
+    mutationFn: signup,
+    onError: (error) => {
+      console.error('회원가입 실패:', error);
+      if (error instanceof AxiosError) {
+        alert(error.message);
+      } else {
+        alert('회원가입에 실패했습니다. 다시 시도해 주세요.');
       }
     },
   });

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -189,13 +189,9 @@ export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean)
 };
 
 // 프로젝트 연동하기
-export const useLinkProject = (successCallback: () => void) => {
+export const useLinkProject = () => {
   return useMutation<ProjectDetailResponse, AxiosError, LinkProjectRequest>({
     mutationFn: linkProject,
-    onSuccess: (response) => {
-      console.log(response);
-      if (successCallback) successCallback();
-    },
     onError: (error) => {
       alert('프로젝트 연동 요청에 실패했습니다.');
       console.log(error);


### PR DESCRIPTION
## 💡 ISSUE 번호

#130 

<br/>

## 🔎 작업 내용

- authService들의 successCallback 삭제
  - mutateAsync를 사용하면 successCallback을 넘겨 줄 필요가 없어서, 기존의 콜백 함수들을 다 async-await으로 변경했습니다.
  - 다른 도메인 서비스들은 mutateAsync로 바꿀만한 것도 있고 아닌 것도 있는 것 같아 수정하지 않았습니다.

- 회원가입/비밀번호 재설정 시 각 input과 버튼의 disalbed 처리를 정리했습니다.
  - 회원가입 같은 경우, 기존에 api를 직접 호출하던 부분을 useMutation 훅으로 수정했습니다.
 

<br/>

## 📢 주의 및 리뷰 요청

- 전체적으로 테스트를 해보았으나 제가 놓친 부분이 있을 수 있으니, 가능하시다면 흐름 테스트 부탁드립니다 !! (동영상을 첨부하려 했는데, 용량 제한으로 첨부는 못했습니다 ㅠ__ㅠ)


<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
