### PR TITLE
Feat/#137 PRism 분석하기 애니메이션 제작

### DIFF
--- a/src/components/common/spinner/index.ts
+++ b/src/components/common/spinner/index.ts
@@ -1,2 +1,3 @@
 export { default as PageSpinner } from './pageSpinner/PageSpinner';
 export { default as ComponentSpinner } from './componentSpinner/ComponentSpinner';
+export { default as PRismSpinner } from './prismSpinner/PRismSpinner';

--- a/src/components/common/spinner/prismSpinner/PRismSpinner.module.css
+++ b/src/components/common/spinner/prismSpinner/PRismSpinner.module.css
@@ -1,0 +1,95 @@
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.pyramid-loader {
+  position: relative;
+  width: 70px;
+  height: 70px;
+  display: block;
+  transform-style: preserve-3d;
+  transform: rotateX(-20deg);
+  background-color: transparent;
+}
+
+.pyramid-loader::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 120px;
+  height: 120px;
+  background: radial-gradient(rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0) 70%);
+  background-blend-mode: screen;
+  transform: translate(-50%, -50%);
+  filter: blur(35px);
+  z-index: -1;
+  animation: pulse 1.5s infinite;
+}
+
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  animation: spin 4s linear infinite;
+}
+
+@keyframes spin {
+  100% {
+    transform: rotateY(720deg);
+  }
+}
+
+.pyramid-loader .wrapper .side {
+  width: 70px;
+  height: 70px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  transform-origin: center top;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.pyramid-loader .wrapper .side1 {
+  transform: rotateZ(-30deg) rotateY(90deg);
+  background: conic-gradient(#2bdeac, #ac2fff, #d8cce6, #2f2585);
+}
+
+.pyramid-loader .wrapper .side2 {
+  transform: rotateZ(30deg) rotateY(90deg);
+  background: conic-gradient(#2f2585, #d8cce6, #8062fa, #2bdeac);
+}
+
+.pyramid-loader .wrapper .side3 {
+  transform: rotateX(30deg);
+  background: conic-gradient(#2f2585, #d8cce6, #ac2fff, #2bdeac);
+}
+
+.pyramid-loader .wrapper .side4 {
+  transform: rotateX(-30deg);
+  background: conic-gradient(#2bdeac, #8062fa, #d8cce6, #2f2585);
+}
+
+.pyramid-loader .wrapper .shadow {
+  width: 60px;
+  height: 60px;
+  background: #8b5ad5;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  transform: rotateX(90deg) translateZ(-40px);
+  filter: blur(12px);
+}

--- a/src/components/common/spinner/prismSpinner/PRismSpinner.tsx
+++ b/src/components/common/spinner/prismSpinner/PRismSpinner.tsx
@@ -1,0 +1,16 @@
+import styles from './PRismSpinner.module.css';
+import { cn } from '@/lib/utils';
+
+export default function PrismSpinner() {
+  return (
+    <div className={styles['pyramid-loader']}>
+      <div className={styles.wrapper}>
+        <span className={cn(styles.side, styles.side1)}></span>
+        <span className={cn(styles.side, styles.side2)}></span>
+        <span className={cn(styles.side, styles.side3)}></span>
+        <span className={cn(styles.side, styles.side4)}></span>
+        <span className={styles.shadow}></span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/prism/PRismAnalyzeAnimation.tsx
+++ b/src/components/domain/prism/PRismAnalyzeAnimation.tsx
@@ -1,0 +1,17 @@
+import PRismSpinner from '@/components/common/spinner/prismSpinner/PRismSpinner';
+
+export default function PRismAnalyzeAnimation() {
+  return (
+    <div className="fixed left-0 top-0 z-50 flex h-full w-full items-center justify-center bg-black bg-opacity-85">
+      <div className="relative z-20 flex max-h-[80vh] w-[50vw] flex-col items-center border-none bg-transparent p-4 shadow-none">
+        <div className="relative z-30 mt-10">
+          <PRismSpinner />
+        </div>
+        <div className="relative z-30 mt-14 text-center text-[15px] font-medium text-white md:text-base lg:text-lg">
+          <p>AI가 PRism 분석리포트를 생성 중이에요.</p>
+          <p>잠시만 기다려 주세요.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/prism/PRismAnalyzeAnimation.tsx
+++ b/src/components/domain/prism/PRismAnalyzeAnimation.tsx
@@ -1,4 +1,4 @@
-import PRismSpinner from '@/components/common/spinner/prismSpinner/PRismSpinner';
+import { PRismSpinner } from '@/components/common/spinner';
 
 export default function PRismAnalyzeAnimation() {
   return (

--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -45,8 +45,9 @@ const ErrorMessage = () => {
 
   return (
     <MessageBox
-      title={<div className="my-2 body6">PRism 분석 갱신에 실패했습니다.</div>}
+      title={<div className="my-1 body6">PRism 분석 갱신에 실패했습니다.</div>}
       titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
+      description="다시 시도해 주세요."
       footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
     />
   );

--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -9,36 +9,6 @@ interface ProjectEvaluationButtonProps {
   projectId: number;
 }
 
-export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
-  const { openModal, closeModal } = useModalStore();
-
-  const handlePRismUpdateSuccess = () => {
-    closeModal();
-    openModal(<SuccessMessage />);
-  };
-
-  const handlePRismUpdateError = () => {
-    closeModal();
-    openModal(<ErrorMessage />);
-  };
-
-  const updatePRismMutation = useUpdatePRismEvaluation({
-    onSuccess: handlePRismUpdateSuccess,
-    onError: handlePRismUpdateError,
-  });
-
-  const handleStartEvaluation = () => {
-    openModal(<PRismAnalyzeAnimation />);
-    updatePRismMutation.mutate(projectId);
-  };
-
-  return (
-    <Button className="h-8 mobile2" onClick={handleStartEvaluation}>
-      PRism 분석 시작
-    </Button>
-  );
-}
-
 // 갱신 실패 메시지창
 const ErrorMessage = () => {
   const { closeModal } = useModalStore();
@@ -65,3 +35,27 @@ const SuccessMessage = () => {
     />
   );
 };
+
+export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
+  const { openModal, closeModal } = useModalStore();
+
+  const { mutateAsync } = useUpdatePRismEvaluation({
+    onError: () => {
+      closeModal();
+      openModal(<ErrorMessage />);
+    },
+  });
+
+  const handleStartEvaluation = async () => {
+    openModal(<PRismAnalyzeAnimation />);
+    await mutateAsync(projectId);
+    closeModal();
+    openModal(<SuccessMessage />);
+  };
+
+  return (
+    <Button className="h-8 mobile2" onClick={handleStartEvaluation}>
+      PRism 분석 시작
+    </Button>
+  );
+}

--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -1,18 +1,34 @@
-import { Button } from '@/components/ui/button';
+import { useModalStore } from '@/stores/modalStore';
 import { useUpdatePRismEvaluation } from '@/hooks/queries/usePRismService';
+import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import MessageBox from '@/components/common/messgeBox/MessageBox';
+import PRismAnalyzeAnimation from '../../prism/PRismAnalyzeAnimation';
 
 interface ProjectEvaluationButtonProps {
   projectId: number;
 }
 
 export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
+  const { openModal, closeModal } = useModalStore();
+
   const handlePRismUpdateSuccess = () => {
-    // 나중에 메시지박스 추가? 피그마에 내용 없어서 alert 처리함
-    alert('PRism 분석이 갱신되었어요!');
+    closeModal();
+    openModal(<SuccessMessage />);
   };
-  const updatePRismMutation = useUpdatePRismEvaluation(handlePRismUpdateSuccess);
+
+  const handlePRismUpdateError = () => {
+    closeModal();
+    openModal(<ErrorMessage />);
+  };
+
+  const updatePRismMutation = useUpdatePRismEvaluation({
+    onSuccess: handlePRismUpdateSuccess,
+    onError: handlePRismUpdateError,
+  });
 
   const handleStartEvaluation = () => {
+    openModal(<PRismAnalyzeAnimation />);
     updatePRismMutation.mutate(projectId);
   };
 
@@ -22,3 +38,29 @@ export default function ProjectEvaluationButton({ projectId }: ProjectEvaluation
     </Button>
   );
 }
+
+// 갱신 실패 메시지창
+const ErrorMessage = () => {
+  const { closeModal } = useModalStore();
+
+  return (
+    <MessageBox
+      title={<div className="my-2 body6">PRism 분석 갱신에 실패했습니다.</div>}
+      titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
+      footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
+    />
+  );
+};
+
+// 갱신 성공 메시지창
+const SuccessMessage = () => {
+  const { closeModal } = useModalStore();
+
+  return (
+    <MessageBox
+      title={<div className="my-2 body6">PRism 분석이 갱신되었어요!</div>}
+      titleIcon={<CheckCircle className="h-7 w-7 stroke-purple-500" />}
+      footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
+    />
+  );
+};

--- a/src/hooks/queries/usePRismService.ts
+++ b/src/hooks/queries/usePRismService.ts
@@ -30,12 +30,18 @@ export const useUserOverallProjectAnalysis = (userId: string) => {
 };
 
 // 프리즘 평가 갱신하기
-export const useUpdatePRismEvaluation = (successCallback: () => void) => {
+export const useUpdatePRismEvaluation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: () => void;
+  onError: () => void;
+}) => {
   return useMutation<PRismEvaluationUpdateResponse, AxiosError, number>({
     mutationFn: updatePrismEvaluation,
     onSuccess: (response) => {
       console.log(response);
-      if (successCallback) successCallback();
+      if (onSuccess) onSuccess();
     },
     onError: (error) => {
       // 추후 케이스 나눠서 메시징 처리 예정
@@ -50,9 +56,8 @@ export const useUpdatePRismEvaluation = (successCallback: () => void) => {
       // // 3번. 평가를 한 사람이 더이상 없는데 갱신을 할 경우
       // code: PeerReviewCode_400_5,
       // reason: 이미 평가 갱신이 완료되었습니다
-
-      alert('PRism 분석 갱신에 실패했습니다.');
       console.log(error);
+      if (onError) onError();
     },
   });
 };

--- a/src/hooks/queries/usePRismService.ts
+++ b/src/hooks/queries/usePRismService.ts
@@ -30,19 +30,9 @@ export const useUserOverallProjectAnalysis = (userId: string) => {
 };
 
 // 프리즘 평가 갱신하기
-export const useUpdatePRismEvaluation = ({
-  onSuccess,
-  onError,
-}: {
-  onSuccess: () => void;
-  onError: () => void;
-}) => {
+export const useUpdatePRismEvaluation = ({ onError }: { onError: (error: AxiosError) => void }) => {
   return useMutation<PRismEvaluationUpdateResponse, AxiosError, number>({
     mutationFn: updatePrismEvaluation,
-    onSuccess: (response) => {
-      console.log(response);
-      if (onSuccess) onSuccess();
-    },
     onError: (error) => {
       // 추후 케이스 나눠서 메시징 처리 예정
       // 1번. 평가 갱신할 권한이 없을 경우(project owner가 아닐경우)
@@ -57,7 +47,7 @@ export const useUpdatePRismEvaluation = ({
       // code: PeerReviewCode_400_5,
       // reason: 이미 평가 갱신이 완료되었습니다
       console.log(error);
-      if (onError) onError();
+      if (onError) onError(error);
     },
   });
 };

--- a/src/hooks/queries/usePRismService.ts
+++ b/src/hooks/queries/usePRismService.ts
@@ -30,11 +30,10 @@ export const useUserOverallProjectAnalysis = (userId: string) => {
 };
 
 // 프리즘 평가 갱신하기
-export const useUpdatePRismEvaluation = ({ onError }: { onError: (error: AxiosError) => void }) => {
+export const useUpdatePRismEvaluation = () => {
   return useMutation<PRismEvaluationUpdateResponse, AxiosError, number>({
     mutationFn: updatePrismEvaluation,
     onError: (error) => {
-      // 추후 케이스 나눠서 메시징 처리 예정
       // 1번. 평가 갱신할 권한이 없을 경우(project owner가 아닐경우)
       // code: PeerReviewCode_400_3,
       // reason: 평가 갱신을 할 권한이 없습니다.
@@ -47,7 +46,17 @@ export const useUpdatePRismEvaluation = ({ onError }: { onError: (error: AxiosEr
       // code: PeerReviewCode_400_5,
       // reason: 이미 평가 갱신이 완료되었습니다
       console.log(error);
-      if (onError) onError(error);
+      const errorMessage = error.code;
+      switch (errorMessage) {
+        case 'PeerReviewCode_400_3':
+          throw 'PRism 분석 권한이 없습니다.';
+        case 'PeerReviewCode_400_4':
+          throw 'PRism 분석에 실패했습니다';
+        case 'PeerReviewCode_400_5':
+          throw 'PRism 분석이 최신 상태입니다.';
+        default:
+          throw 'PRism 분석 업데이트에 실패했습니다.';
+      }
     },
   });
 };


### PR DESCRIPTION
## 💡 ISSUE 번호

#137 

<br/>

## 🔎 작업 내용

- `PRismSpinner` 컴포넌트 생성
- `PRismAnalyzeAnimation` 컴포넌트 생성
- `ProjectEvaluationButto`에 연결


<br/>

## 📢 주의 및 리뷰 요청

- 현재 프로젝트 관리 페이지에서 [PRism 분석 시작] 버튼을 누르면 api 응답을 받기까지 평균 10초 내외의 시간이 소요되고 있습니다.
이 분석하기가 저희 서비스의 메인 기능이고, 비용을 들여 ai를 사용하고 있는데, 그 부분이 화면에서는 강조되지 않는 것 같아 조금 아쉬웠습니다. 따라서 버튼을 누르고 api 응답을 받아오는 시간 사이에 애니메이션이 추가하였습니다. 
- loader 대신 애니메이션을 추가하고자 하는 이유는, 10여 초 동안 로더가 돌게 되면 서비스 자체가 느린 것처럼 보일 수 있기 때문입니다.
- 문구는 혜선 님께서 주신 것 중 두 번째를 적용했습니다. 

> 1안: ‘AI가 softskill을 다각도로 분석하여 PRism 리포트를 생성 중이에요. 잠시만 기다려주세요.’

> 2안: ‘AI가 PRism 분석리포트를 생성 중이에요. 잠시만 기다려주세요.’

- 제가 전달드렸던 두 가지 버전 중 2안으로 의견이 모아져 그 버전으로 넣었고, overlay는 좀 더 옅게 변경했습니다. (이거보다 더 흐려지면 뒤에 페이지가 많이 비쳐서 애니메이션에 집중이 덜 되더라고요...!)
- 시안보다 glow 효과도 조금 더 키워봤습니다. 
- 메시지 처리는 GUI가 없어서 기존에 사용하던 `MessageBox`를 활용했고, 적절한 폰트와 아이콘으로 배치했습니다.
- 그냥 하나의 파일에 합칠까 하다가, 기존 spinner와 비슷한 방식으로 짜고 싶어서 피라미드 애니메이션/ 적용 모달 컴포넌트를 분리했습니다. (spinner가 common에 위치해 있어서 분리하고 싶었습니다..!)
- project 하위에 있는 버튼에 연결되긴 하지만, 아무래도 너무 prism에서 사용되는 컴포넌트라고 판단되어 위치는 `prismSpinner`는 `common/spinner` 하위에, `PRismAnalyzeAnimation`은 `domain/prism` 하위에 두었습니다.
- 에러 처리를 위해 `useUpdatePRismEvaluation` hook을 조금 수정했고, 정상 동작 확인했습니다!


### 갱신 성공
https://github.com/user-attachments/assets/ec21bc18-6835-4f38-addb-7daa3ac10455

### 갱신 실패
https://github.com/user-attachments/assets/80616b3c-b835-49ba-a3e6-6fbe8f575c3d

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
