### PR TITLE
Style/#156 프로젝트 평가 반응형 깨지는거 수정, 이미지 저장 스피너 캡처 수정

### DIFF
--- a/src/components/domain/preview/PreviewModal.tsx
+++ b/src/components/domain/preview/PreviewModal.tsx
@@ -33,6 +33,10 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
       setIsDownloading(true);
       // 필요한 스타일 및 이미지가 렌더링 되게 setTimeout 추가
       setTimeout(async () => {
+        setIsDownloading(false);
+        // 페이지 로딩창 끄고 state 변경 적용을 위해 큐에 promise 추가
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
         if (captureRef.current) {
           const canvas = await html2canvas(captureRef.current, {
             backgroundColor: 'transparent', // 배경색 투명하게 설정
@@ -44,8 +48,6 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
           link.href = image;
           link.download = `${saveType === SAVE_TYPE.PROJECT ? 'prism-project' : 'prism-profile'}.png`;
           link.click();
-
-          setIsDownloading(false);
         }
       }, 1000);
     } catch (error) {

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -61,7 +61,7 @@ export default function ProjectSummaryCard({
       className={cn(isCardDisabled && 'cursor-default active:bg-white')}
       onClick={handleCardClick}>
       <div className="flex min-h-[176px] flex-col justify-between lg:h-44 lg:flex-row">
-        <div className="mb-4 flex w-full flex-wrap gap-3 sm:gap-6 lg:mb-0 lg:w-[80%] lg:gap-12">
+        <div className="mb-4 flex w-full gap-3 sm:gap-6 lg:mb-0 lg:w-[80%] lg:gap-12">
           <LeftSection projectData={projectData} forSaveImage={forSaveImage} />
           {(variant === PROJECT_CARD_VARIANT.MY_PROFILE ||
             variant === PROJECT_CARD_VARIANT.OTHER_PROFILE) && (


### PR DESCRIPTION
## 💡 ISSUE 번호

#156

<br/>

## 🔎 작업 내용

- 이미지 저장 시 페이지 스피너 함께 캡처되는 것 수정 (0.2초 딜레이 줌)
- 프로젝트 한줄 평가 길어질 때 flex-wrap 적용되어 ui가 깨지고 있음 -> flex-wrap 속성 제거 (화면 너비 줄어들어도 설명은 우측에 위치하게 수정됨)
<img width="447" alt="image" src="https://github.com/user-attachments/assets/931eae4e-86c8-4415-898e-c279e75ea1e3">


<br/>

## 📢 주의 및 리뷰 요청

- 내용을 입력해주세요.

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
