### PR TITLE
Feat/#165 평가 링크 재발송 로딩처리 추가

### DIFF
--- a/src/components/common/input/CheckTagInput.tsx
+++ b/src/components/common/input/CheckTagInput.tsx
@@ -1,8 +1,5 @@
-'use client';
-
 import { cn } from '@/lib/utils';
 import { Check, Plus } from 'lucide-react';
-import useIsDarkMode from '@/hooks/useIsDarkMode';
 
 interface CheckTagInputProps {
   value: string;
@@ -17,8 +14,9 @@ export default function CheckTagInput({
   isChecked = false,
   isDisabled = false,
   onClick,
+  mode = 'LIGHT',
 }: CheckTagInputProps) {
-  const isDarkMode = useIsDarkMode();
+  const isDarkMode = mode === 'DARK';
 
   const getClassNameByStatus = (): string => {
     if (isChecked)

--- a/src/components/domain/project/projectButton/ProjectSendEvaluationLink.tsx
+++ b/src/components/domain/project/projectButton/ProjectSendEvaluationLink.tsx
@@ -14,9 +14,10 @@ export default function ProjectSendEvaluationLink({ projectId }: ProjectSendEval
   const sendSurveyLinkMutation = useSendSurveyLink();
 
   const handleSendEvaluationLink = async () => {
+    openModal(<SendSurveyCompleteMessage />);
+
     try {
       await sendSurveyLinkMutation.mutateAsync({ projectId });
-      openModal(<SendSurveyCompleteMessage />);
     } catch (error) {
       console.error('평가지 보내기 실패:', error);
     }
@@ -52,6 +53,7 @@ const SendSurveyCompleteMessage = () => {
   return (
     <MessageBox
       title={renderTitle()}
+      description="이메일 전송에는 최대 1분이 소요될 수 있습니다."
       titleIcon={<Send className="stroke-purple-500" />}
       footer={<MessageBox.MessageConfirmButton text="완료" onClick={handleClickComplete} />}
     />

--- a/src/components/domain/project/projectButton/ProjectSendEvaluationLink.tsx
+++ b/src/components/domain/project/projectButton/ProjectSendEvaluationLink.tsx
@@ -23,7 +23,12 @@ export default function ProjectSendEvaluationLink({ projectId }: ProjectSendEval
   };
 
   return (
-    <Button className="h-8 display5" variant="outline" onClick={handleSendEvaluationLink}>
+    <Button
+      className="h-8 display5"
+      variant="outline"
+      onClick={handleSendEvaluationLink}
+      disabled={sendSurveyLinkMutation.isPending}
+      pending={sendSurveyLinkMutation.isPending}>
       평가 링크 다시보내기
     </Button>
   );

--- a/src/components/domain/survey/answerType/TextAnswer.tsx
+++ b/src/components/domain/survey/answerType/TextAnswer.tsx
@@ -11,7 +11,7 @@ const Instruction = ({ indicator }: InstructionProps) => (
   <div className="my-9 flex-center">
     <p className="text-gray-600 body7">
       <span className="text-black body6">{indicator}</span>을
-      <span className="text-purple-600 body6"> 한가지로 요약</span>하고,
+      <span className="text-purple-600 body6"> 한 가지로 요약</span>하고,
       <span className="text-black body6">그렇게 생각한 이유</span>를{' '}
       <span className="text-purple-600 body6">자세한 예</span>를 들어 설명해 주세요.
     </p>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -54,8 +54,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           <div className="absolute inset-0 flex items-center justify-center p-3">
             <svg
               className={cn(
-                'h-full w-fit animate-spin',
-                variant === 'outline' ? 'text-purple-900' : 'text-white',
+                'animate-spin',
+                variant === 'outline' ? 'text-gray-500 h-5 w-5' : 'h-full w-fit text-white',
               )}
               xmlns="http://www.w3.org/2000/svg"
               fill="none"


### PR DESCRIPTION
## 💡 ISSUE 번호

#165 

<br/>

## 🔎 작업 내용

-  평가 링크 재발송 로딩처리 추가 (요청 중 재요청 막기)
- 평가 링크 보내자마자 api response에 관계 없이 메시지 띄우기

<br/>

## 📢 주의 및 리뷰 요청

- 현재 평가 링크 재발송 버튼이 계속 눌려서 여러번 클릭 시, 서버에 부하가 걸리는 문제가 있었습니다. 그래서 일단 버튼을 누르면 응답에 관계없이 먼저 메시지를 출력하고, 이메일 발송 지연 시간에 대한 안내 문구를 추가했습니다. 대신 버튼에 pending 처리를 추가하는 방향을 수정했습니다. 

### 문제 상황

https://github.com/user-attachments/assets/970dd929-cfdd-425d-b223-349cb8bc09ee

### 변경 전

https://github.com/user-attachments/assets/db2c368b-9adb-4226-9a55-b598bf0ffb82

### 변경 후

https://github.com/user-attachments/assets/11f8140b-fd03-4bc8-add8-a68a7da584ff


- outline일 때 spinner 보라색이 살짝 어색해서 아래와 같이 추가했습니다. 
<img width="398" alt="스크린샷 2024-08-10 오전 2 07 37" src="https://github.com/user-attachments/assets/84ac6fdd-3205-4e1a-86aa-adb29eaa88f9">

-----
### 추가
- 랜딩페이지에서 라이트모드일 때 검색창 하단 카테고리 컬러가 라이트로 변경되는 버그가 있어서 수정했습니다. 
<img width="910" alt="스크린샷 2024-08-10 오전 2 51 58" src="https://github.com/user-attachments/assets/63eada95-fdba-42c9-af28-36d014dd09a0">
<img width="930" alt="스크린샷 2024-08-10 오전 2 53 00" src="https://github.com/user-attachments/assets/05f55051-abbc-49ae-83fc-9461b2312ef8">



<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
