### PR TITLE
Feat/#141 알림 및 오류 메시지박스 처리

### DIFF
--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -12,7 +12,7 @@ import SelectTagModalLayout from '@/components/common/modal/SelectTagModalLayout
 import BorderCard from '@/components/common/card/BorderCard';
 import TagInput from '@/components/common/input/TagInput';
 import MessageBox from '@/components/common/messgeBox/MessageBox';
-import { AlertCircle, CheckCircle2, Pencil } from 'lucide-react';
+import { AlertCircle, CheckCircle, Pencil } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 // 로그인 한 사용자의 프로필 수정 페이지
@@ -235,7 +235,7 @@ const ProfileSaveSuccessMessage = () => {
   return (
     <MessageBox
       title="프로필이 성공적으로 수정되었습니다."
-      titleIcon={<CheckCircle2 className="stroke-purple-500" />}
+      titleIcon={<CheckCircle className="stroke-purple-500" />}
       footer={<MessageBox.MessageConfirmButton text="확인" />}
       contentClassName="max-w-[550px]"
     />

--- a/src/app/project/link/page.tsx
+++ b/src/app/project/link/page.tsx
@@ -3,15 +3,18 @@
 import SearchInput from '@/components/common/input/SearchInput';
 import ProjectRegisterButton from '@/components/domain/project/projectButton/ProjectRegisterButton';
 import LinkProjectList from '@/components/domain/project/projectList/LinkProjectList';
+import useMessageBox from '@/hooks/useMessageBox';
 import { useState } from 'react';
 
 // 검색어 입력창이 포함되고, 검색어에 대한 의존성이 높은 페이지라 'use client' 선언했습니다.
 export default function ProjectLinkPage() {
+  const { showConfirmMessageBox } = useMessageBox();
+
   const [keyword, setKeyword] = useState<string>('');
   const handleSearch = (value: string) => {
     if (value === '') {
       // 검색어가 비어있으면 알림창을 띄운다
-      alert('검색어를 입력해주세요.');
+      showConfirmMessageBox('검색어를 입력해주세요.');
       return;
     }
     setKeyword(value);

--- a/src/components/common/messgeBox/MessageBox.tsx
+++ b/src/components/common/messgeBox/MessageBox.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { cn } from '@/lib/utils';
-
 import { Button } from '@/components/ui/button';
 import ModalLayout from '@/components/common/modal/ModalLayout';
 
@@ -28,22 +26,20 @@ export default function MessageBox({
   contentClassName = '',
 }: MessageBoxProps) {
   return (
-    <div className="shadow-custom-6px">
-      <ModalLayout
-        title={
-          <div className="flex-col-center">
-            {titleIcon && <div className="mb-3 flex justify-center">{titleIcon}</div>}
-            <div className="body2">{title}</div>
-            {subTitle && <div className="text-purple-800 mt-1 display4">{subTitle}</div>}
-          </div>
-        }
-        description={description}
-        contentClassName={cn('max-w-[500px] px-[50px]', contentClassName)}
-        transparentOverlay={true}
-        footer={<div className="mt-5 w-full gap-3 flex-center">{footer}</div>}
-        showCloseButton={showCloseButton}
-      />
-    </div>
+    <ModalLayout
+      title={
+        <div className="flex-col-center">
+          {titleIcon && <div className="mb-3 flex justify-center">{titleIcon}</div>}
+          <div className="body2">{title}</div>
+          {subTitle && <div className="text-purple-800 mt-1 display4">{subTitle}</div>}
+        </div>
+      }
+      description={description}
+      contentClassName={`max-w-[510px] px-[50px] ${contentClassName}`}
+      transparentOverlay={true}
+      footer={<div className="mt-5 w-full gap-3 flex-center">{footer}</div>}
+      showCloseButton={showCloseButton}
+    />
   );
 }
 

--- a/src/components/common/messgeBox/MessageBox.tsx
+++ b/src/components/common/messgeBox/MessageBox.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import ModalLayout from '@/components/common/modal/ModalLayout';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+import { Button } from '@/components/ui/button';
+import ModalLayout from '@/components/common/modal/ModalLayout';
+
 import { useModalStore } from '@/stores/modalStore';
 
 // 제목, 버튼 필수

--- a/src/components/common/modal/SelectTagModalLayout.tsx
+++ b/src/components/common/modal/SelectTagModalLayout.tsx
@@ -10,6 +10,7 @@ import { Search } from 'lucide-react';
 import TagInput from '../input/TagInput';
 import { useModalStore } from '@/stores/modalStore';
 import { cn } from '@/lib/utils';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface SelectTagModalLayoutProps {
   title: string;
@@ -31,6 +32,8 @@ export default function SelectTagModalLayout({
   defaultSelectTagList,
   onSelectComplete,
 }: SelectTagModalLayoutProps) {
+  const { showConfirmMessageBox } = useMessageBox();
+
   const [message, setMessage] = useState<string>('');
   const [messageClassName, setMessageClassname] = useState<string>('');
 
@@ -60,7 +63,7 @@ export default function SelectTagModalLayout({
   const handleSelectComplete = () => {
     // 선택한 태그가 없는데 '적용하기' 버튼을 누를 경우 return 처리
     if (selectList.size === 0) {
-      alert('선택한 태그가 없습니다.');
+      showConfirmMessageBox('선택한 태그가 없습니다.');
       return;
     }
     onSelectComplete(Array.from(selectList));

--- a/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
+++ b/src/components/domain/auth/resetPassword/ResetPasswordModal.tsx
@@ -27,11 +27,13 @@ import {
 import ModalLayout from '@/components/common/modal/ModalLayout';
 import LoginModal from '../login/LoginModal';
 import { cn } from '@/lib/utils';
+import useMessageBox from '@/hooks/useMessageBox';
 
 export default function ResetPasswordModal() {
   const id = useId();
   const isSmallScreen = useMediaQuery('(max-width: 430px)');
   const { openModal, closeModal } = useModalStore();
+  const { showConfirmMessageBox } = useMessageBox();
 
   // mutation
   const sendEmailCodeMutation = useSendEmailCode();
@@ -116,7 +118,7 @@ export default function ResetPasswordModal() {
         password: data.newPassword,
       });
       closeModal();
-      alert('비밀번호가 성공적으로 재설정되었습니다.');
+      showConfirmMessageBox('비밀번호가 성공적으로 재설정되었습니다.');
       setTimeout(() => {
         openModal(<LoginModal />);
       }, 200);

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -35,7 +35,7 @@ export default function SignupModal() {
   const id = useId();
   const isSmallScreen = useMediaQuery('(max-width: 430px)');
   const { openModal, closeModal } = useModalStore();
-  const { showErrorMessageBox } = useMessageBox();
+  const { showErrorMessageBox, showConfirmMessageBox } = useMessageBox();
 
   // mutation
   const checkEmailExistMutation = useCheckEmailExists();
@@ -93,7 +93,7 @@ export default function SignupModal() {
       } else {
         clearErrors('email');
         setIsEmailExistChecked(true);
-        alert('사용 가능한 이메일입니다.');
+        showConfirmMessageBox('사용 가능한 이메일입니다.');
       }
     } catch (error) {
       setError('email', { type: 'manual', message: '이메일 중복 확인 중 오류가 발생했습니다.' });
@@ -135,7 +135,7 @@ export default function SignupModal() {
         authCode: data.certification,
         password: data.password,
       });
-      alert('회원가입이 성공적으로 완료되었습니다!');
+      showConfirmMessageBox('회원가입이 성공적으로 완료되었습니다!');
 
       closeModal();
       setTimeout(() => {

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -29,11 +29,13 @@ import {
   useVerifyAuthCode,
 } from '@/hooks/queries/useAuthService';
 import LoginModal from '../login/LoginModal';
+import useErrorMessageBox from '@/hooks/useErrorMessageBox';
 
 export default function SignupModal() {
   const id = useId();
   const isSmallScreen = useMediaQuery('(max-width: 430px)');
   const { openModal, closeModal } = useModalStore();
+  const { showErrorMessageBox } = useErrorMessageBox();
 
   // mutation
   const checkEmailExistMutation = useCheckEmailExists();
@@ -49,7 +51,7 @@ export default function SignupModal() {
   const handleTimerEnd = () => {
     setIsCodeSent(false);
     setValue('certification', '');
-    alert('인증시간이 만료되었습니다. 다시 시도해주세요.');
+    showErrorMessageBox('인증시간이 만료되었습니다.');
   };
 
   const { timeLeft, startTimer, isRunning } = useTimer(300, handleTimerEnd);
@@ -141,7 +143,7 @@ export default function SignupModal() {
       }, 200);
     } catch (error) {
       console.error(`회원가입 실패: ${error}`);
-      alert('회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      showErrorMessageBox('회원가입 중 오류가 발생했습니다.');
     }
   };
 

--- a/src/components/domain/auth/signup/SignupModal.tsx
+++ b/src/components/domain/auth/signup/SignupModal.tsx
@@ -29,13 +29,13 @@ import {
   useVerifyAuthCode,
 } from '@/hooks/queries/useAuthService';
 import LoginModal from '../login/LoginModal';
-import useErrorMessageBox from '@/hooks/useErrorMessageBox';
+import useMessageBox from '@/hooks/useMessageBox';
 
 export default function SignupModal() {
   const id = useId();
   const isSmallScreen = useMediaQuery('(max-width: 430px)');
   const { openModal, closeModal } = useModalStore();
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   // mutation
   const checkEmailExistMutation = useCheckEmailExists();

--- a/src/components/domain/preview/PreviewModal.tsx
+++ b/src/components/domain/preview/PreviewModal.tsx
@@ -14,7 +14,7 @@ import { SAVE_TYPE, type SaveType } from '@/models/preview/previewModels';
 import { Share2 } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import { PageSpinner } from '@/components/common/spinner';
-import useErrorMessageBox from '@/hooks/useErrorMessageBox';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface PreviewModalProps {
   saveType: SaveType;
@@ -25,7 +25,7 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
   const userId = useUserStore((state) => state.user?.userId);
   const captureRef = useRef<HTMLDivElement>(null);
   const openModal = useModalStore((state) => state.openModal);
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
 

--- a/src/components/domain/preview/PreviewModal.tsx
+++ b/src/components/domain/preview/PreviewModal.tsx
@@ -14,6 +14,7 @@ import { SAVE_TYPE, type SaveType } from '@/models/preview/previewModels';
 import { Share2 } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import { PageSpinner } from '@/components/common/spinner';
+import useErrorMessageBox from '@/hooks/useErrorMessageBox';
 
 interface PreviewModalProps {
   saveType: SaveType;
@@ -24,6 +25,7 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
   const userId = useUserStore((state) => state.user?.userId);
   const captureRef = useRef<HTMLDivElement>(null);
   const openModal = useModalStore((state) => state.openModal);
+  const { showErrorMessageBox } = useErrorMessageBox();
 
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
 
@@ -52,7 +54,7 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
       }, 1000);
     } catch (error) {
       console.error('이미지 저장 중 오류 발생:', error);
-      alert('이미지 저장 중 오류가 발생했습니다.');
+      showErrorMessageBox('이미지 저장 중 오류가 발생했습니다.');
     }
   };
 
@@ -70,7 +72,7 @@ export default function PreviewModal({ saveType, projectId }: PreviewModalProps)
       openModal(<ShareMessageBox />);
     } catch (error) {
       console.error('클립보드 복사 실패:', error);
-      alert('클립보드 복사에 실패했습니다.');
+      showErrorMessageBox('클립보드 복사에 실패했습니다.');
     }
   };
 

--- a/src/components/domain/prism/report/ReportBlur.tsx
+++ b/src/components/domain/prism/report/ReportBlur.tsx
@@ -1,4 +1,5 @@
 import { ComponentSpinner } from '@/components/common/spinner';
+import useIsDarkMode from '@/hooks/useIsDarkMode';
 import { cn } from '@/lib/utils';
 
 interface ReportBlurProps {
@@ -14,6 +15,7 @@ export default function ReportBlur({
   isError = false,
   forSaveImage = false,
 }: ReportBlurProps) {
+  const isDarkMode = useIsDarkMode();
   const message = isError
     ? 'PRism을 로드하는데 문제가 발생했습니다.'
     : isLoading
@@ -29,7 +31,8 @@ export default function ReportBlur({
   return (
     <div
       className={cn(
-        'bg-white absolute inset-1 z-10 flex gap-3 rounded-[30px] backdrop-blur-sm flex-col-center',
+        'absolute inset-1 z-10 flex gap-3 rounded-[30px] backdrop-blur-sm flex-col-center',
+        isDarkMode ? 'bg-gray-800' : 'bg-white',
         forSaveImage ? 'bg-opacity-90' : 'bg-opacity-70',
       )}>
       {isLoading && <ComponentSpinner />}

--- a/src/components/domain/prism/report/ReportBlur.tsx
+++ b/src/components/domain/prism/report/ReportBlur.tsx
@@ -31,7 +31,7 @@ export default function ReportBlur({
   return (
     <div
       className={cn(
-        'absolute inset-1 z-10 flex gap-3 rounded-[30px] backdrop-blur-sm flex-col-center',
+        'absolute inset-1 z-10 flex gap-3 rounded-[30px] backdrop-blur-[8px] flex-col-center',
         isDarkMode ? 'bg-gray-800' : 'bg-white',
         forSaveImage ? 'bg-opacity-90' : 'bg-opacity-70',
       )}>

--- a/src/components/domain/project/projectButton/ProjectEditDeleteButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEditDeleteButton.tsx
@@ -5,6 +5,7 @@ import { useModalStore } from '@/stores/modalStore';
 import { useDeleteProject, useGetProjectDetails } from '@/hooks/queries/useProjectService';
 import ProjectRegisterModal from '../projectRegisterModal/ProjectRegisterModal';
 import { ProjectForm } from '@/models/project/projectModels';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface ProjectEditDeleteButtonProps {
   projectId: number;
@@ -45,14 +46,14 @@ interface DeleteConfirmMessageProps {
   closeModal: () => void;
 }
 const DeleteConfirmMessage = ({ projectId, closeModal }: DeleteConfirmMessageProps) => {
+  const { showConfirmMessageBox } = useMessageBox();
+
   const handleDeleteProjectSuccess = () => {
     closeModal();
-    alert('프로젝트가 정상적으로 삭제되었습니다.');
+    showConfirmMessageBox('프로젝트가 정상적으로 삭제되었습니다.');
   };
   const deleteMutaion = useDeleteProject(handleDeleteProjectSuccess);
-  const handleCancel = () => {
-    closeModal();
-  };
+
   const handleDelete = () => {
     deleteMutaion.mutate(projectId);
   };
@@ -62,7 +63,7 @@ const DeleteConfirmMessage = ({ projectId, closeModal }: DeleteConfirmMessagePro
       titleIcon={<Trash2 className="stroke-purple-500" />}
       footer={
         <>
-          <MessageBox.MessageConfirmButton isPrimary={false} text="취소" onClick={handleCancel} />
+          <MessageBox.MessageConfirmButton isPrimary={false} text="취소" />
           <MessageBox.MessageConfirmButton
             text="삭제"
             onClick={handleDelete}

--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -4,7 +4,7 @@ import { CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import MessageBox from '@/components/common/messgeBox/MessageBox';
 import PRismAnalyzeAnimation from '../../prism/PRismAnalyzeAnimation';
-import useErrorMessageBox from '@/hooks/useErrorMessageBox';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface ProjectEvaluationButtonProps {
   projectId: number;
@@ -12,7 +12,7 @@ interface ProjectEvaluationButtonProps {
 
 export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
   const { openModal, closeModal } = useModalStore();
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   const updatePRismMutation = useUpdatePRismEvaluation();
 

--- a/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectEvaluationButton.tsx
@@ -1,9 +1,10 @@
 import { useModalStore } from '@/stores/modalStore';
 import { useUpdatePRismEvaluation } from '@/hooks/queries/usePRismService';
-import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import MessageBox from '@/components/common/messgeBox/MessageBox';
 import PRismAnalyzeAnimation from '../../prism/PRismAnalyzeAnimation';
+import useErrorMessageBox from '@/hooks/useErrorMessageBox';
 
 interface ProjectEvaluationButtonProps {
   projectId: number;
@@ -11,6 +12,7 @@ interface ProjectEvaluationButtonProps {
 
 export default function ProjectEvaluationButton({ projectId }: ProjectEvaluationButtonProps) {
   const { openModal, closeModal } = useModalStore();
+  const { showErrorMessageBox } = useErrorMessageBox();
 
   const updatePRismMutation = useUpdatePRismEvaluation();
 
@@ -30,7 +32,7 @@ export default function ProjectEvaluationButton({ projectId }: ProjectEvaluation
       } else {
         errorMessage = 'PRism 분석 업데이트에 실패했습니다.';
       }
-      openModal(<ErrorMessage message={errorMessage} />);
+      showErrorMessageBox(errorMessage);
     }
   };
 
@@ -40,19 +42,6 @@ export default function ProjectEvaluationButton({ projectId }: ProjectEvaluation
     </Button>
   );
 }
-
-// 갱신 실패 메시지창
-const ErrorMessage = ({ message }: { message: string }) => {
-  const { closeModal } = useModalStore();
-
-  return (
-    <MessageBox
-      title={<div className="my-1 body6">{message}</div>}
-      titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
-      footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
-    />
-  );
-};
 
 // 갱신 성공 메시지창
 const SuccessMessage = () => {

--- a/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
+++ b/src/components/domain/project/projectButton/ProjectRegisterButton.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import LoginModal from '../../auth/login/LoginModal';
-import ProjectRegisterModal from '@/components/domain/project/projectRegisterModal/ProjectRegisterModal';
-import { useModalStore } from '@/stores/modalStore';
-import { useAuthStore } from '@/stores/authStore';
+import { cn } from '@/lib/utils';
 import { ClipboardEdit } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+
+import { useModalStore } from '@/stores/modalStore';
+import { useAuthStore } from '@/stores/authStore';
+
+import LoginModal from '../../auth/login/LoginModal';
+import ProjectRegisterModal from '@/components/domain/project/projectRegisterModal/ProjectRegisterModal';
 
 interface ProjectRegisterButtonProps {
   text?: string;
@@ -18,11 +20,11 @@ export default function ProjectRegisterButton({
   className,
 }: ProjectRegisterButtonProps) {
   const openModal = useModalStore((state) => state.openModal);
+
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   const handleOpenProjectRegisterModal = () => {
     if (!isLoggedIn) {
-      alert('로그인하고 프로젝트를 시작해보세요!'); // 임시 alert
       openModal(<LoginModal />);
       return;
     }

--- a/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
+++ b/src/components/domain/project/projectCard/ProjectSummaryCard.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/models/project/projectModels';
 import { formatDateToDotSeparatedYYYYMMDD } from '@/lib/dateTime';
 import { useRouter } from 'next/navigation';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface ProjectSummaryCardProps {
   projectData: ProjectSummaryData;
@@ -35,6 +36,7 @@ export default function ProjectSummaryCard({
 }: ProjectSummaryCardProps) {
   const router = useRouter();
   const projectId = projectData.projectId;
+  const { showConfirmMessageBox } = useMessageBox();
 
   // 프로젝트 카드 disabled 조건 : 관리자용, 연동용, 이미지 저장용
   const isCardDisabled =
@@ -54,7 +56,7 @@ export default function ProjectSummaryCard({
     if (route) {
       router.push(route);
     } else {
-      alert('이동할 페이지가 없습니다.');
+      showConfirmMessageBox('이동할 페이지가 없습니다.');
     }
   };
   return (

--- a/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
+++ b/src/components/domain/project/projectLinkModal/ProjectLinkModal.tsx
@@ -23,6 +23,7 @@ import { cn } from '@/lib/utils';
 
 import { useModalStore } from '@/stores/modalStore';
 import { useUserStore } from '@/stores/userStore';
+import useMessageBox from '@/hooks/useMessageBox';
 
 import { CheckCircle } from 'lucide-react';
 
@@ -60,6 +61,8 @@ export default function ProjectLinkModal({ projectId }: ProjectLinkModalProps) {
   const authCode = watch('authCode');
 
   const { openModal, closeModal } = useModalStore();
+  const { showConfirmMessageBox } = useMessageBox();
+
   const loginUser = useUserStore((state) => state.user);
   const [isCodeSent, setIsCodeSent] = useState(false); // 인증번호가 전송된 상태인지
 
@@ -74,7 +77,7 @@ export default function ProjectLinkModal({ projectId }: ProjectLinkModalProps) {
     // 인증번호 입력 칸 초기화
     setValue('authCode', '');
     // 알림 띄우기
-    alert('인증시간이 만료되었습니다. 인증번호를 다시 요청해주세요.');
+    showConfirmMessageBox('인증시간이 만료되었습니다. 인증번호를 다시 요청해주세요.');
   };
   const { timeLeft, startTimer } = useTimer(300, handleTimerEnd);
 
@@ -163,7 +166,7 @@ export default function ProjectLinkModal({ projectId }: ProjectLinkModalProps) {
     alertShownRef.current = true;
     closeModal();
     setTimeout(() => {
-      alert('이미 연동된 프로젝트입니다.');
+      showConfirmMessageBox('이미 연동된 프로젝트입니다.');
     });
     return null;
   }

--- a/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
+++ b/src/components/domain/project/projectRegisterModal/ProjectRegisterModal.tsx
@@ -33,6 +33,7 @@ import { useSendSurveyLink } from '@/hooks/queries/useSurveyService';
 import { formatDateToYYYYMMDDHHmmss } from '@/lib/dateTime';
 import MessageBox from '@/components/common/messgeBox/MessageBox';
 import ProjectEmailConsentModal from '../../auth/privacyPolicy/ProjectEmailConsentModal';
+import useMessageBox from '@/hooks/useMessageBox';
 
 const STEPS: ProjectRegisterHeaderStep[] = [
   {
@@ -67,6 +68,8 @@ export default function ProjectRegisterModal({
 }: ProjectRegisterModalProps) {
   const [currStep, setCurrStep] = useState<number>(0);
   const { openModal, closeModal } = useModalStore();
+  const { showConfirmMessageBox } = useMessageBox();
+
   const userData = useUserStore((state) => state.user);
 
   // 프로젝트 저장 성공 콜백함수
@@ -80,7 +83,7 @@ export default function ProjectRegisterModal({
   // 프로젝트 수정 성공 콜백함수
   const handleProjectUpdateSuccess = () => {
     closeModal();
-    alert('프로젝트가 수정되었습니다.');
+    showConfirmMessageBox('프로젝트가 수정되었습니다.');
   };
 
   const createMutation = useCreateProject(handleProjectCreateSuccess);

--- a/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
+++ b/src/components/domain/project/projectSearch/ProjectSearchBar.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { User, Clipboard, ChevronDown, ChevronUp } from 'lucide-react';
 import CheckTagInput from '@/components/common/input/CheckTagInput';
 import SearchInput from '@/components/common/input/SearchInput';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface ProjectSearchBarProps {
   defaultKeyword?: string;
@@ -28,6 +29,7 @@ export default function ProjectSearchBar({
 }: ProjectSearchBarProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const { showConfirmMessageBox } = useMessageBox();
   const setSearchCondition = useSearchStore((state) => state.setSearchCondition);
   const [selectTabType, setSelectTabType] = useState<SearchType>(SearchTypeConst.MEMBER_NAME);
   const [isDetailVisible, toggleDetailVisibility] = useReducer(
@@ -52,7 +54,7 @@ export default function ProjectSearchBar({
 
   const handleSearch = (keyword: string) => {
     if (keyword === '' && selectList.size === 0) {
-      alert('검색어 입력 또는 카테고리를 선택해 주세요.');
+      showConfirmMessageBox('검색어 입력 또는 카테고리를 선택해 주세요.');
       return;
     }
     // 검색 시 현재 검색어 searchStore에 저장

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -28,7 +28,8 @@ import {
   type CarouselApi,
 } from '@/components/ui/carousel';
 import { Button } from '@/components/ui/button';
-import { MailOpen, Sparkles, AlertTriangle } from 'lucide-react';
+import { MailOpen, Sparkles } from 'lucide-react';
+import useErrorMessageBox from '@/hooks/useErrorMessageBox';
 
 interface SurveyPageProps {
   surveyData: SurveyLinkResponse;
@@ -41,6 +42,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   const [teamMembers, setTeamMembers] = useState<string[]>([]);
 
   const { openModal, closeModal } = useModalStore();
+  const { showErrorMessageBox } = useErrorMessageBox();
 
   const methods = useForm<SurveyFormValues>({
     defaultValues: {
@@ -123,7 +125,10 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
       if (error instanceof z.ZodError) {
         console.error('Validation failed:', error.errors);
       }
-      openModal(<ErrorMessage />);
+      showErrorMessageBox(
+        '모든 항목을 작성해주세요.',
+        '누락된 응답이 있습니다. 모든 질문에 답변해주세요.',
+      );
     }
   };
 
@@ -187,7 +192,7 @@ const SubmitSurveyMessage = ({ handleClickSubmit }: { handleClickSubmit: () => v
       footer={
         <>
           <MessageBox.MessageConfirmButton text="이전으로" onClick={closeModal} isPrimary={false} />
-          <MessageBox.MessageConfirmButton text="제출하기" onClick={handleClickSubmit} isPrimary />
+          <MessageBox.MessageConfirmButton text="제출하기" onClick={handleClickSubmit} />
         </>
       }
     />
@@ -211,23 +216,9 @@ const CompletionMessage = () => {
       titleIcon={<Sparkles className="h-6 w-6 stroke-purple-600" />}
       footer={
         <Link href="/mypage">
-          <MessageBox.MessageConfirmButton text="내 평가 결과 보러가기" isPrimary={true} />
+          <MessageBox.MessageConfirmButton text="내 평가 결과 보러가기" />
         </Link>
       }
-    />
-  );
-};
-
-// 오류 메시지창(유효성 검사)
-const ErrorMessage = () => {
-  const { closeModal } = useModalStore();
-
-  return (
-    <MessageBox
-      title={<div>모든 항목을 작성해주세요.</div>}
-      description="누락된 응답이 있습니다. 모든 질문에 답변해주세요."
-      titleIcon={<AlertTriangle className="h-6 w-6 stroke-danger-500" />}
-      footer={<MessageBox.MessageConfirmButton text="확인" onClick={closeModal} isPrimary />}
     />
   );
 };

--- a/src/components/domain/survey/SurveyPage.tsx
+++ b/src/components/domain/survey/SurveyPage.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/components/ui/carousel';
 import { Button } from '@/components/ui/button';
 import { MailOpen, Sparkles } from 'lucide-react';
-import useErrorMessageBox from '@/hooks/useErrorMessageBox';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface SurveyPageProps {
   surveyData: SurveyLinkResponse;
@@ -42,7 +42,7 @@ export default function SurveyPage({ surveyData }: SurveyPageProps) {
   const [teamMembers, setTeamMembers] = useState<string[]>([]);
 
   const { openModal, closeModal } = useModalStore();
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   const methods = useForm<SurveyFormValues>({
     defaultValues: {

--- a/src/components/domain/user/UserSummaryCard.tsx
+++ b/src/components/domain/user/UserSummaryCard.tsx
@@ -15,6 +15,7 @@ import { maskEmail, maskName } from '@/lib/masking';
 
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/stores/userStore';
+import useMessageBox from '@/hooks/useMessageBox';
 
 interface UserSummaryCardProps {
   userData: UserSummaryData;
@@ -29,12 +30,14 @@ export default function UserSummaryCard({
 }: UserSummaryCardProps) {
   const router = useRouter();
   const user = useUserStore((state) => state.user);
+  const { showConfirmMessageBox } = useMessageBox();
+
   const isPublicUser = variant === USER_CARD_VARIANT.MEMBER_PUBLIC;
   const isPrivateUser = variant === USER_CARD_VARIANT.MEMBER_PRIVATE;
 
   const handleOpenUserProfile = () => {
     if (!isPublicUser) {
-      alert('비공개 팀원입니다.');
+      showConfirmMessageBox('비공개 팀원입니다.');
       return;
     }
     if (user?.userId === userData.userId) {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'relative mx-4 w-full max-w-2xl rounded-[30px] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 dark:bg-gray-800 sm:mx-0',
+          'relative mx-4 w-full max-w-2xl rounded-[30px] border bg-background p-6 shadow-lg duration-200 dark:border-gray-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 dark:bg-gray-800 sm:mx-0',
           className,
         )}
         {...props}>

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -70,14 +70,14 @@ export const useLogin = () => {
 };
 
 export const useLogout = () => {
-  const { showErrorMessageBox } = useMessageBox();
+  const { showErrorMessageBox, showConfirmMessageBox } = useMessageBox();
   const logoutAuthStore = useAuthStore((state) => state.logout);
 
   return useMutation<LogoutResponse, AxiosError>({
     mutationFn: logout,
     onSuccess: () => {
       logoutAuthStore();
-      alert('로그아웃 되었습니다.');
+      showConfirmMessageBox('로그아웃 되었습니다.');
 
       // 로그아웃 시 홈 페이지로 리다이렉트
       window.location.href = '/';
@@ -96,12 +96,12 @@ export const useLogout = () => {
 };
 
 export const useSendEmailCode = () => {
-  const { showErrorMessageBox } = useMessageBox();
+  const { showErrorMessageBox, showConfirmMessageBox } = useMessageBox();
 
   return useMutation<SendEmailCodeResponse, AxiosError, SendEmailCodeRequest>({
     mutationFn: sendEmailCode,
     onSuccess: () => {
-      alert('인증번호가 전송되었습니다.');
+      showConfirmMessageBox('인증번호가 전송되었습니다.');
     },
     onError: (error) => {
       console.error('인증번호 발송 실패:', error);
@@ -147,7 +147,7 @@ export const useCheckEmailExists = () => {
     onError: (error) => {
       console.error('이메일 중복검사 실패:', error);
       if (error instanceof AxiosError) {
-        alert(error.message);
+        showErrorMessageBox(error.message);
       } else {
         showErrorMessageBox('이메일 중복검사에 실패했습니다.');
       }

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -54,11 +54,9 @@ export const useLogin = () => {
           roles: data.interestJobs,
           skills: data.skills, // 백엔드에서 아직 안넘겨줌. 빈값으로 설정
         });
-
-        alert('로그인에 성공했습니다.');
       } catch (error) {
         console.error('유저 데이터 가져오기 실패:', error);
-        alert('로그인은 성공했지만 유저 데이터를 가져오는데 실패했습니다.');
+        console.error('로그인은 성공했지만 유저 데이터를 가져오는데 실패했습니다.');
       } finally {
         closeModal();
       }

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -27,11 +27,11 @@ import {
 } from '../../services/api/authApi';
 import { useUserStore } from '@/stores/userStore';
 import { userDataByLoginUser } from '@/services/api/userApi';
-import useErrorMessageBox from '../useErrorMessageBox';
+import useMessageBox from '../useMessageBox';
 
 export const useLogin = () => {
   const { closeModal } = useModalStore();
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
   const setUser = useUserStore((state) => state.setUser);
   const loginAuthStore = useAuthStore((state) => state.login);
 
@@ -70,7 +70,7 @@ export const useLogin = () => {
 };
 
 export const useLogout = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
   const logoutAuthStore = useAuthStore((state) => state.logout);
 
   return useMutation<LogoutResponse, AxiosError>({
@@ -96,7 +96,7 @@ export const useLogout = () => {
 };
 
 export const useSendEmailCode = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<SendEmailCodeResponse, AxiosError, SendEmailCodeRequest>({
     mutationFn: sendEmailCode,
@@ -111,7 +111,7 @@ export const useSendEmailCode = () => {
 };
 
 export const useVerifyAuthCode = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<VerifyAuthCodeResponse, AxiosError, VerifyAuthCodeRequest>({
     mutationFn: verifyAuthCode,
@@ -123,14 +123,14 @@ export const useVerifyAuthCode = () => {
 };
 
 export const useResetPassword = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<ResetPasswordResponse, AxiosError, ResetPasswordRequest>({
     mutationFn: resetPassword,
     onError: (error) => {
       console.error('비밀번호 재설정 실패:', error);
       if (error instanceof AxiosError) {
-        alert(error.message);
+        showErrorMessageBox(error.message);
       } else {
         showErrorMessageBox('비밀번호 재설정에 실패했습니다.');
       }
@@ -139,7 +139,7 @@ export const useResetPassword = () => {
 };
 
 export const useCheckEmailExists = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<EmailExistsResponse, AxiosError, string>({
     mutationFn: checkEmailExists,
@@ -156,7 +156,7 @@ export const useCheckEmailExists = () => {
 };
 
 export const useSignup = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<SignupResponse, AxiosError, SignupRequest>({
     mutationFn: signup,

--- a/src/hooks/queries/useAuthService.ts
+++ b/src/hooks/queries/useAuthService.ts
@@ -27,9 +27,11 @@ import {
 } from '../../services/api/authApi';
 import { useUserStore } from '@/stores/userStore';
 import { userDataByLoginUser } from '@/services/api/userApi';
+import useErrorMessageBox from '../useErrorMessageBox';
 
 export const useLogin = () => {
   const { closeModal } = useModalStore();
+  const { showErrorMessageBox } = useErrorMessageBox();
   const setUser = useUserStore((state) => state.setUser);
   const loginAuthStore = useAuthStore((state) => state.login);
 
@@ -55,20 +57,20 @@ export const useLogin = () => {
           skills: data.skills, // 백엔드에서 아직 안넘겨줌. 빈값으로 설정
         });
       } catch (error) {
-        console.error('유저 데이터 가져오기 실패:', error);
-        console.error('로그인은 성공했지만 유저 데이터를 가져오는데 실패했습니다.');
+        console.error('로그인은 성공했지만, 유저 데이터 가져오기 실패:', error);
       } finally {
         closeModal();
       }
     },
     onError: (error) => {
-      alert('로그인에 실패했습니다. 다시 시도해 주세요.');
       console.error('로그인 실패: ', error);
+      showErrorMessageBox('로그인에 실패했습니다.');
     },
   });
 };
 
 export const useLogout = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
   const logoutAuthStore = useAuthStore((state) => state.logout);
 
   return useMutation<LogoutResponse, AxiosError>({
@@ -88,12 +90,14 @@ export const useLogout = () => {
     },
     onError: (error) => {
       console.error('로그아웃 실패:', error);
-      alert('로그아웃에 실패했습니다. 다시 시도해 주세요.');
+      showErrorMessageBox('로그아웃에 실패했습니다.');
     },
   });
 };
 
 export const useSendEmailCode = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<SendEmailCodeResponse, AxiosError, SendEmailCodeRequest>({
     mutationFn: sendEmailCode,
     onSuccess: () => {
@@ -101,22 +105,26 @@ export const useSendEmailCode = () => {
     },
     onError: (error) => {
       console.error('인증번호 발송 실패:', error);
-      alert('인증번호 발송에 실패했습니다. 다시 시도해 주세요.');
+      showErrorMessageBox('인증번호 발송에 실패했습니다.');
     },
   });
 };
 
 export const useVerifyAuthCode = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<VerifyAuthCodeResponse, AxiosError, VerifyAuthCodeRequest>({
     mutationFn: verifyAuthCode,
     onError: (error) => {
       console.error('인증번호 인증 실패:', error);
-      alert('인증번호 인증에 실패했습니다. 다시 시도해 주세요.');
+      showErrorMessageBox('인증번호 인증에 실패했습니다.');
     },
   });
 };
 
 export const useResetPassword = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<ResetPasswordResponse, AxiosError, ResetPasswordRequest>({
     mutationFn: resetPassword,
     onError: (error) => {
@@ -124,13 +132,15 @@ export const useResetPassword = () => {
       if (error instanceof AxiosError) {
         alert(error.message);
       } else {
-        alert('비밀번호 재설정에 실패했습니다. 다시 시도해 주세요.');
+        showErrorMessageBox('비밀번호 재설정에 실패했습니다.');
       }
     },
   });
 };
 
 export const useCheckEmailExists = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<EmailExistsResponse, AxiosError, string>({
     mutationFn: checkEmailExists,
 
@@ -139,21 +149,23 @@ export const useCheckEmailExists = () => {
       if (error instanceof AxiosError) {
         alert(error.message);
       } else {
-        alert('이메일 중복검사에 실패했습니다. 다시 시도해 주세요.');
+        showErrorMessageBox('이메일 중복검사에 실패했습니다.');
       }
     },
   });
 };
 
 export const useSignup = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<SignupResponse, AxiosError, SignupRequest>({
     mutationFn: signup,
     onError: (error) => {
       console.error('회원가입 실패:', error);
       if (error instanceof AxiosError) {
-        alert(error.message);
+        showErrorMessageBox(error.message);
       } else {
-        alert('회원가입에 실패했습니다. 다시 시도해 주세요.');
+        showErrorMessageBox('회원가입에 실패했습니다.');
       }
     },
   });

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -31,10 +31,13 @@ import {
 } from '@/services/api/projectApi';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import useErrorMessageBox from '../useErrorMessageBox';
 
 // 프로젝트 생성하기
 export const useCreateProject = (successCallback: (projectId: number) => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
   const queryClient = useQueryClient();
+
   return useMutation<ProjectCreateResponse, AxiosError, ProjectCreateRequest>({
     mutationFn: createProject,
     onSuccess: (response, requestProjectData) => {
@@ -70,14 +73,15 @@ export const useCreateProject = (successCallback: (projectId: number) => void) =
       if (successCallback) successCallback(createdProjectId);
     },
     onError: (error) => {
-      alert('프로젝트 등록에 실패했습니다.');
-      console.log(error);
+      console.error(error);
+      showErrorMessageBox('프로젝트 등록에 실패했습니다.');
     },
   });
 };
 
 // 프로젝트 삭제하기
 export const useDeleteProject = (successCallback: () => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
   const queryClient = useQueryClient();
 
   return useMutation<ProjectDeleteResponse, AxiosError, number>({
@@ -97,14 +101,15 @@ export const useDeleteProject = (successCallback: () => void) => {
       if (successCallback) successCallback();
     },
     onError: (error) => {
-      alert('프로젝트 삭제에 실패했습니다.');
-      console.log(error);
+      console.error(error);
+      showErrorMessageBox('프로젝트 삭제에 실패했습니다.');
     },
   });
 };
 
 // 프로젝트 수정하기
 export const useUpdateProject = (successCallback: () => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
   const queryClient = useQueryClient();
 
   return useMutation<
@@ -137,14 +142,16 @@ export const useUpdateProject = (successCallback: () => void) => {
       if (successCallback) successCallback();
     },
     onError: (error) => {
-      alert('프로젝트 수정에 실패했습니다.');
-      console.log(error);
+      console.error(error);
+      showErrorMessageBox('프로젝트 수정에 실패했습니다.');
     },
   });
 };
 
 // 프로젝트 수정을 위해 상세 데이터 조회하기 (클릭 시 조회를 목적으로 하기에 mutaion 사용)
 export const useGetProjectDetails = (successCallback: (projectDetailData: ProjectForm) => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<ProjectDetailResponse, AxiosError, number>({
     mutationFn: getEditProjectDetails,
     onSuccess: (response) => {
@@ -167,14 +174,16 @@ export const useGetProjectDetails = (successCallback: (projectDetailData: Projec
       if (successCallback) successCallback(projectDetilData);
     },
     onError: (error) => {
-      alert('프로젝트 상세 정보 조회에 실패했습니다.');
       console.error('프로젝트 상세 정보 조회 실패:', error);
+      showErrorMessageBox('프로젝트 상세 정보 조회에 실패했습니다.');
     },
   });
 };
 
 // 특정 프로젝트에서 본인의 익명 처리 여부 설정 (공개/비공개)
 export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean) => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<MyProjectVisibilityResponse, AxiosError, MyProjectVisibilityRequest>({
     mutationFn: updateMyProjectVisibility,
     onSuccess: (response, requsetCondition) => {
@@ -182,24 +191,26 @@ export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean)
       if (successCallback) successCallback(requsetCondition.visibility);
     },
     onError: (error) => {
-      alert('프로젝트 공개 설정에 실패했습니다.');
       console.log(error);
+      showErrorMessageBox('프로젝트 공개 설정에 실패했습니다.');
     },
   });
 };
 
 // 프로젝트 연동하기
 export const useLinkProject = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<ProjectDetailResponse, AxiosError, LinkProjectRequest>({
     mutationFn: linkProject,
     onError: (error) => {
-      alert('프로젝트 연동 요청에 실패했습니다.');
       console.log(error);
+      showErrorMessageBox('프로젝트 연동 요청에 실패했습니다.');
     },
   });
 };
 
-// 홈, 검색 페이지에서 프로젝트 검색하기 (Mutaion)
+// 홈, 검색 페이지에서 프로젝트 검색하기
 export const useSearchProjects = (condition: ProjectSearchRequest) => {
   return useQuery<ProjectSearchResponse, AxiosError>({
     queryKey: [

--- a/src/hooks/queries/useProjectService.ts
+++ b/src/hooks/queries/useProjectService.ts
@@ -31,11 +31,11 @@ import {
 } from '@/services/api/projectApi';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import useErrorMessageBox from '../useErrorMessageBox';
+import useMessageBox from '../useMessageBox';
 
 // 프로젝트 생성하기
 export const useCreateProject = (successCallback: (projectId: number) => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
   const queryClient = useQueryClient();
 
   return useMutation<ProjectCreateResponse, AxiosError, ProjectCreateRequest>({
@@ -81,7 +81,7 @@ export const useCreateProject = (successCallback: (projectId: number) => void) =
 
 // 프로젝트 삭제하기
 export const useDeleteProject = (successCallback: () => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
   const queryClient = useQueryClient();
 
   return useMutation<ProjectDeleteResponse, AxiosError, number>({
@@ -109,7 +109,7 @@ export const useDeleteProject = (successCallback: () => void) => {
 
 // 프로젝트 수정하기
 export const useUpdateProject = (successCallback: () => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
   const queryClient = useQueryClient();
 
   return useMutation<
@@ -150,7 +150,7 @@ export const useUpdateProject = (successCallback: () => void) => {
 
 // 프로젝트 수정을 위해 상세 데이터 조회하기 (클릭 시 조회를 목적으로 하기에 mutaion 사용)
 export const useGetProjectDetails = (successCallback: (projectDetailData: ProjectForm) => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<ProjectDetailResponse, AxiosError, number>({
     mutationFn: getEditProjectDetails,
@@ -182,7 +182,7 @@ export const useGetProjectDetails = (successCallback: (projectDetailData: Projec
 
 // 특정 프로젝트에서 본인의 익명 처리 여부 설정 (공개/비공개)
 export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean) => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<MyProjectVisibilityResponse, AxiosError, MyProjectVisibilityRequest>({
     mutationFn: updateMyProjectVisibility,
@@ -199,7 +199,7 @@ export const useUpdateMyProjectVisibility = (successCallback: (checked: boolean)
 
 // 프로젝트 연동하기
 export const useLinkProject = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<ProjectDetailResponse, AxiosError, LinkProjectRequest>({
     mutationFn: linkProject,

--- a/src/hooks/queries/useSurveyService.ts
+++ b/src/hooks/queries/useSurveyService.ts
@@ -10,7 +10,7 @@ import type {
   SubmitSurveyRequest,
   SubmitSurveyResponse,
 } from '@/models/survey/surveyApiModels';
-import useErrorMessageBox from '../useErrorMessageBox';
+import useMessageBox from '../useMessageBox';
 
 // 설문 링크 가져오기
 export const useFetchSurveyLink = (params: SurveyLinkRequest) => {
@@ -24,7 +24,7 @@ export const useFetchSurveyLink = (params: SurveyLinkRequest) => {
 
 // 설문 링크 보내기
 export const useSendSurveyLink = () => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<SendSurveyLinkResponse, AxiosError, SendSurveyLinkRequest>({
     mutationFn: sendSurveyLink,
@@ -37,7 +37,7 @@ export const useSendSurveyLink = () => {
 
 // 설문 응답 제출하기
 export const useSubmitSurvey = (successCallback: () => void) => {
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<
     SubmitSurveyResponse,

--- a/src/hooks/queries/useSurveyService.ts
+++ b/src/hooks/queries/useSurveyService.ts
@@ -10,6 +10,7 @@ import type {
   SubmitSurveyRequest,
   SubmitSurveyResponse,
 } from '@/models/survey/surveyApiModels';
+import useErrorMessageBox from '../useErrorMessageBox';
 
 // 설문 링크 가져오기
 export const useFetchSurveyLink = (params: SurveyLinkRequest) => {
@@ -23,17 +24,21 @@ export const useFetchSurveyLink = (params: SurveyLinkRequest) => {
 
 // 설문 링크 보내기
 export const useSendSurveyLink = () => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<SendSurveyLinkResponse, AxiosError, SendSurveyLinkRequest>({
     mutationFn: sendSurveyLink,
     onError: (error) => {
       console.error('Send Survey Link Error:', error);
-      alert('평가 링크 발송에 실패했습니다.');
+      showErrorMessageBox('평가 링크 발송에 실패했습니다.');
     },
   });
 };
 
 // 설문 응답 제출하기
 export const useSubmitSurvey = (successCallback: () => void) => {
+  const { showErrorMessageBox } = useErrorMessageBox();
+
   return useMutation<
     SubmitSurveyResponse,
     AxiosError,
@@ -46,7 +51,7 @@ export const useSubmitSurvey = (successCallback: () => void) => {
     },
     onError: (error) => {
       console.error('Submit Survey Error:', error);
-      alert('평가 제출에 실패했습니다.');
+      showErrorMessageBox('평가 제출에 실패했습니다.');
     },
   });
 };

--- a/src/hooks/queries/useUserService.ts
+++ b/src/hooks/queries/useUserService.ts
@@ -8,7 +8,7 @@ import {
 import { AxiosError } from 'axios';
 import { User } from '@/models/user/userModels';
 import { useUserStore } from '@/stores/userStore';
-import useErrorMessageBox from '../useErrorMessageBox';
+import useMessageBox from '../useMessageBox';
 
 // userId로 특정 사용자의 Profile Data 가져오기
 export const useUserProfileByUserId = (userId: string) => {
@@ -24,7 +24,7 @@ export const useUserProfileByUserId = (userId: string) => {
 export const useUpdateProfile = (successCallback: () => void) => {
   const queryClient = useQueryClient();
   const { user, setUser } = useUserStore();
-  const { showErrorMessageBox } = useErrorMessageBox();
+  const { showErrorMessageBox } = useMessageBox();
 
   return useMutation<UpdateProfileResponse, AxiosError, UpdateProfileRequest>({
     mutationFn: updateProfile,

--- a/src/hooks/queries/useUserService.ts
+++ b/src/hooks/queries/useUserService.ts
@@ -8,6 +8,7 @@ import {
 import { AxiosError } from 'axios';
 import { User } from '@/models/user/userModels';
 import { useUserStore } from '@/stores/userStore';
+import useErrorMessageBox from '../useErrorMessageBox';
 
 // userId로 특정 사용자의 Profile Data 가져오기
 export const useUserProfileByUserId = (userId: string) => {
@@ -23,6 +24,7 @@ export const useUserProfileByUserId = (userId: string) => {
 export const useUpdateProfile = (successCallback: () => void) => {
   const queryClient = useQueryClient();
   const { user, setUser } = useUserStore();
+  const { showErrorMessageBox } = useErrorMessageBox();
 
   return useMutation<UpdateProfileResponse, AxiosError, UpdateProfileRequest>({
     mutationFn: updateProfile,
@@ -46,7 +48,7 @@ export const useUpdateProfile = (successCallback: () => void) => {
     },
     onError: (error) => {
       console.error('프로필 수정 실패:', error);
-      alert('프로필 수정에 실패했습니다. 다시 시도해 주세요.');
+      showErrorMessageBox('프로필 수정에 실패했습니다.');
     },
   });
 };

--- a/src/hooks/useErrorMessageBox.tsx
+++ b/src/hooks/useErrorMessageBox.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { useModal } from './useModal';
+import MessageBox from '@/components/common/messgeBox/MessageBox';
+import { AlertTriangle } from 'lucide-react';
+
+export default function useErrorMessageBox() {
+  const { openModal } = useModal();
+
+  const showErrorMessageBox = useCallback(
+    (title: string = '알 수 없는 오류가 발생했습니다.', subTitle = '다시 시도해 주세요.') => {
+      openModal(
+        <MessageBox
+          titleIcon={<AlertTriangle className="stroke-danger-500 h-6 w-6" />}
+          title={title}
+          description={subTitle}
+          footer={<MessageBox.MessageConfirmButton text="확인" />}
+        />,
+      );
+    },
+    [openModal],
+  );
+
+  return { showErrorMessageBox };
+}

--- a/src/hooks/useMessageBox.tsx
+++ b/src/hooks/useMessageBox.tsx
@@ -1,10 +1,27 @@
 import { useCallback } from 'react';
-import { useModal } from './useModal';
-import MessageBox from '@/components/common/messgeBox/MessageBox';
-import { AlertTriangle } from 'lucide-react';
 
-export default function useErrorMessageBox() {
+import { useModal } from './useModal';
+import { AlertCircle, AlertTriangle } from 'lucide-react';
+import MessageBox from '@/components/common/messgeBox/MessageBox';
+
+/**
+ * 지정 콜백함수가 없는 정보성 메시지 박스
+ */
+export default function useMessageBox() {
   const { openModal } = useModal();
+
+  const showConfirmMessageBox = useCallback(
+    (title: string) => {
+      openModal(
+        <MessageBox
+          titleIcon={<AlertCircle className="h-6 w-6 stroke-purple-500" />}
+          title={title}
+          footer={<MessageBox.MessageConfirmButton text="확인" />}
+        />,
+      );
+    },
+    [openModal],
+  );
 
   const showErrorMessageBox = useCallback(
     (title: string = '알 수 없는 오류가 발생했습니다.', subTitle = '다시 시도해 주세요.') => {
@@ -20,5 +37,5 @@ export default function useErrorMessageBox() {
     [openModal],
   );
 
-  return { showErrorMessageBox };
+  return { showErrorMessageBox, showConfirmMessageBox };
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -173,6 +173,7 @@ const config: Config = {
         '.dark .stroke-gray-800': { stroke: theme('colors.gray.200') },
         '.dark .stroke-gray-700': { stroke: theme('colors.gray.200') },
         '.dark .stroke-gray-600': { stroke: theme('colors.gray.200') },
+        '.dark .stroke-danger-500': { stroke: theme('colors.red.400') },
         '.dark .border-gray-300': { borderColor: theme('colors.gray.600') },
         '.dark .border-gray-200': { borderColor: theme('colors.gray.700') },
         '.dark .border-gray-50': { borderColor: theme('colors.gray.800') },


### PR DESCRIPTION
## 💡 ISSUE 번호

#141 

<br/>

## 🔎 작업 내용


### Dark Mode 관련
- ReportBlur의 dark모드 blur css 수정

**<수정전>**
<img width="600" alt="스크린샷 2024-08-09 오후 7 41 23" src="https://github.com/user-attachments/assets/ccb543f9-2892-4631-930d-33b9e60f3ec4">

**<수정후>**
<img width="600" alt="스크린샷 2024-08-09 오후 7 51 55" src="https://github.com/user-attachments/assets/91bc0de0-3407-42f2-ab4b-96e7e01e61a8">

- ModalLayout이 배경과 구분이 가지 않아 dark:border에 gray-200 설정
  - border 추가하며 메시지박스 기본 너비를 배경과 구분되게 좀 늘렸습니다.

**<수정전>**
<img width="300" alt="스크린샷 2024-08-10 오전 1 13 42" src="https://github.com/user-attachments/assets/a2821f79-b8ba-45da-a6e6-5d5c46808b33">
<img width="300" alt="스크린샷 2024-08-10 오전 1 43 59" src="https://github.com/user-attachments/assets/6b7e872a-50f6-4325-92db-4cd28f7551be">

**<수정후>**
<img width="300" alt="스크린샷 2024-08-10 오전 1 55 28" src="https://github.com/user-attachments/assets/71c84762-15e4-4ff3-bc9d-22e606e2fbae">


### 메시지박스 관련
- 메시지박스로 표시하지 않아도 되는 정보들은 alert 제거

- useMessageBox 훅 추가, alert api 싹 다 MessageBox로 수정
  - 지정된 버튼 클릭 이벤트도 없고 단순히 정보를 보여주는 용도로 사용되는 메시지박스 훅을 하나 추가했습니다.
  - '확인' 버튼 하나만 존재하며 버튼 클릭 시 모달을 닫는 용도로만 사용하려고 합니다.
  - 오류를 표현하는 ErrorMessage, 경고나 정보 알림을 목적으로하는 ConfirmMessage 두개를 생성했으며 ConfirmMessage같은 경우 InfoMessage, AlertMessage 등 네이밍이 애매하여 우선 ConfirmMessage로 정했습니다. 변경 가능하니 의견 부탁드립니다!
 
**<ErrorMessage>**
<img width="300" alt="스크린샷 2024-08-10 오전 1 55 28" src="https://github.com/user-attachments/assets/a5467976-9059-4b9c-a744-8db6076efacf">

**<ConfirmMessage>**
<img width="300" alt="스크린샷 2024-08-10 오전 2 26 41" src="https://github.com/user-attachments/assets/14a6c165-e1c1-40c0-adc9-52f13336d16e">


<br/>

## 📢 주의 및 리뷰 요청

- 로컬에서 빌드 성공 확인했습니다, 혹시 모르니 더블체크 부탁드립니다!
<img width="505" alt="스크린샷 2024-08-10 오전 2 23 20" src="https://github.com/user-attachments/assets/7e7ee3e1-3eff-45c4-831a-f3513504b572">


<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
