### PR TITLE
Feat/#171 링크 바로가기 시, 프로토콜 비어있는 경우 처리/종합지표 이미지 저장 스타일 수정

### DIFF
--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -91,7 +91,7 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                   </div>
                 </h3>
                 <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
-                  <div className="text-purple-800 display6">링크 바로가기</div>
+                  <label className="text-purple-800 display6">링크 바로가기</label>
                   <div className="flex items-center">
                     {projectData.urlVisibility && projectData.projectUrlLink ? (
                       <div className="flex-center">
@@ -108,9 +108,9 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                       '-'
                     )}
                   </div>
-                  <div className="text-gray-600 display6">기관명</div>
+                  <label className="text-gray-600 display6">기관명</label>
                   <div className="text-black display4">{projectData.organizationName}</div>
-                  <div className="text-gray-600 display6">기간</div>
+                  <label className="text-gray-600 display6">기간</label>
                   <div className="text-black display4">
                     <time>{formatDateToDotSeparatedYYYYMMDD(startDate)}</time> -{' '}
                     <time>{formatDateToDotSeparatedYYYYMMDD(endDate)}</time>
@@ -127,9 +127,9 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
               renderInvalidText()
             ) : (
               <div className="grid grid-cols-[90px_1fr] gap-x-8 gap-y-7">
-                <div className="text-gray-600 display6">상세 설명</div>
+                <label className="text-gray-600 display6">상세 설명</label>
                 <p className="text-black display4">{projectData.projectDescription || '-'}</p>
-                <div className="text-gray-600 display6">카테고리</div>
+                <label className="text-gray-600 display6">카테고리</label>
                 <ul className="flex gap-2">
                   {projectData.categories.length === 0
                     ? '-'
@@ -139,7 +139,7 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                         </li>
                       ))}
                 </ul>
-                <div className="text-gray-600 display6">기술스택</div>
+                <label className="text-gray-600 display6">기술스택</label>
                 <ul className="flex flex-wrap gap-2">
                   {projectData.skills.length === 0
                     ? '-'

--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -35,6 +35,16 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
             : USER_CARD_VARIANT.MEMBER_PUBLIC,
     })) || [];
 
+  // URL을 절대 경로로 변환하는 함수
+  const ensureAbsoluteUrl = (url: string): string => {
+    // URL이 http나 https (프로토콜)을 포함하고 있는지 확인
+    if (url.match(/^https?:\/\//i)) {
+      return url; // 이미 절대 경로라면 그대로 반환
+    }
+    // 프로토콜이 없는 경우 '//'를 추가 (프로토콜 상대 URL)
+    return `//${url}`;
+  };
+
   const renderInvalidText = () => (
     <span className="text-gray-600 display6 flex-center">
       {isLoading ? (
@@ -84,14 +94,16 @@ export default function SearchProjectDetailPage({ params }: SearchProjectDetailP
                   <div className="text-purple-800 display6">링크 바로가기</div>
                   <div className="flex items-center">
                     {projectData.urlVisibility && projectData.projectUrlLink ? (
-                      <>
+                      <div className="flex-center">
                         <a
-                          href={projectData.projectUrlLink}
-                          className="text-gray-500 underline underline-offset-4">
+                          href={ensureAbsoluteUrl(projectData.projectUrlLink)}
+                          className="text-gray-500 underline underline-offset-4"
+                          target="_blank"
+                          rel="noopener noreferrer">
                           {projectData.projectUrlLink}
                         </a>
                         <ArrowUpRight className="h-6 w-6 stroke-gray-500" />
-                      </>
+                      </div>
                     ) : (
                       '-'
                     )}

--- a/src/components/domain/prism/PRismAndRadialReport.tsx
+++ b/src/components/domain/prism/PRismAndRadialReport.tsx
@@ -74,7 +74,7 @@ export default function PRismAndRadialReport({
       </div>
       <div className="bg-gray-50 flex min-h-[330px] max-w-[560px] flex-col items-center gap-3 rounded-[30px] px-9 py-3">
         <div className="text-indigo-800 body6">{fromMyProfile && '나의'} PRism 분석 리포트</div>
-        <TripleRadialChart data={radialChartData} />
+        <TripleRadialChart data={radialChartData} forSaveImage={forSaveImage} />
       </div>
     </BorderCard>
   );

--- a/src/components/domain/prism/RadialChartReport.tsx
+++ b/src/components/domain/prism/RadialChartReport.tsx
@@ -61,7 +61,11 @@ export default function RadialChartReport({
           forSaveImage={forSaveImage}
         />
       )}
-      <TripleRadialChart data={radialChartData} radialParentClassName="gap-10" />
+      <TripleRadialChart
+        data={radialChartData}
+        radialParentClassName="gap-10"
+        forSaveImage={forSaveImage}
+      />
     </BorderCard>
   );
 }

--- a/src/components/domain/prism/report/TripleRadialChart.tsx
+++ b/src/components/domain/prism/report/TripleRadialChart.tsx
@@ -14,9 +14,14 @@ export interface RadialChartData {
 interface TripleRadialChartProps {
   data: RadialChartData;
   radialParentClassName?: string;
+  forSaveImage?: boolean;
 }
 
-export default function TripleRadialChart({ data, radialParentClassName }: TripleRadialChartProps) {
+export default function TripleRadialChart({
+  data,
+  radialParentClassName,
+  forSaveImage = false,
+}: TripleRadialChartProps) {
   const gridTextData = [
     { id: 'keyword', label: '키워드', value: data.keyword },
     { id: 'evaluation', label: '팀원 평가 요약', value: data.evaluation },
@@ -37,7 +42,7 @@ export default function TripleRadialChart({ data, radialParentClassName }: Tripl
                 ? '-'
                 : item.id === 'keyword' && Array.isArray(item.value)
                   ? item.value.map((value, index) => (
-                      <TagInput key={index} value={value} isDisabled />
+                      <TagInput key={index} value={value} isDisabled forSaveImage={forSaveImage} />
                     ))
                   : item.value}
             </div>


### PR DESCRIPTION
## 💡 ISSUE 번호

#171

<br/>

## 🔎 작업 내용

### 링크 바로가기
- 테스트 해보다가 발견했는데, 프로젝트 링크에 프로토콜이 없는 채로 기입될 경우, 상대경로로 인식되어 다음과 같이 동작하고 있었습니다.
- 이에, `http`나 `https`로 시작하지 않는 경우 앞에 `//`를 붙여 절대경로로 열리게 url 포맷 함수 추가했습니다.

**[before]**


https://github.com/user-attachments/assets/c2abc1b5-2d86-4ab7-9fd9-3e40fc129e86


**[after]**


https://github.com/user-attachments/assets/4fba030a-68e9-4c5f-bb09-9a8149ebb682



### 종합리포트 태그 배경 없애기
- TripleRadialChart에 saveForImage 옵션 추가했습니다.

**[before]**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/083bdca5-2f29-46ab-8b22-5ae7422796a4">


**[after]**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/81c80518-59fb-42e6-9d3e-b9a25849607f">


<br/>

## 📢 주의 및 리뷰 요청

- 내용을 입력해주세요.

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
