### PR TITLE
Fix/#180 sywg ad 스크립트 설정 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import GlobalFooter from './layout/footer/GlobalFooter';
 import ModalPortal from './layout/modal/ModalPotal';
 import ReactQueryProviders from '@/hooks/useReactQuery';
 import { cn } from '@/lib/utils';
-import Script from 'next/script';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -74,10 +73,7 @@ export default function RootLayout({
   return (
     <html lang="ko" className={pretendard.variable}>
       <head>
-        <Script
-          src="https://cdn.swygbro.com/public/widget/swyg-widget.js"
-          strategy="afterInteractive"
-        />
+        <script defer src="https://cdn.swygbro.com/public/widget/swyg-widget.js"></script>
       </head>
       <body className={cn(pretendard.variable, 'bg-gray-50 flex min-h-screen flex-col')}>
         <ReactQueryProviders>


### PR DESCRIPTION
## 💡 ISSUE 번호

- #180

<br/>

## 🔎 작업 내용

![스크린샷 2024-09-27 오후 8 07 32](https://github.com/user-attachments/assets/6cdc8ef7-50fe-478a-87e7-15ccd72e8cf6)

- 저희 계속 광고와 이용자 집계가 이루어지지 않고 있는 것 같아서 스크립트에서 `strategy="afterInteractive"`를 제거하였습니다.
<br/>

## 📢 주의 및 리뷰 요청

![스크린샷 2024-09-27 오전 3 08 08](https://github.com/user-attachments/assets/be522c32-c9f8-483e-843e-774c71d9db73)

- 네트워크 탭에서 확인해보면 스크립트가 정상적으로 로드되고 있는 것 같은데, 스위그에서는 집계가 이루어지지 않고 있습니다.
- `strategy="afterInteractive"`를 사용하면 광고때문에 페이지 렌더링이 늦어지지 않는 장점이 있지만, 정상동작 확인을 위해 일단 제거해보려고 합니다. 
- 혹시, Next.js의 <Script /> 컴포넌트와 스위그가 호환이 안되나 싶어서...이 부분도 기본 HTML의 `<script defer>`를 사용하여 백그라운드에서 스크립트를 미리 다운로드 하도록 수정해 보았습니다. <Script /> 컴포넌트가 SEO 및 성능 최적화가 기본적으로 적용되는 장점이 있다고 하는데, 일단 런칭 전에 데이터를 받아보는 것이 우선일 것 같아서 이걸로 테스트 해보려고 합니다.

<br/>

## 🔗 Reference

- 작업하면서 참고한 자료가 있다면 추가해주세요.
